### PR TITLE
 Fix Failed to setexeccon error when mounting volume

### DIFF
--- a/volume_manager/Utils.cpp
+++ b/volume_manager/Utils.cpp
@@ -226,7 +226,7 @@ status_t ForkExecvp(const std::vector<std::string>& args) {
     return ForkExecvp(args, nullptr);
 }
 
-status_t ForkExecvp(const std::vector<std::string>& args, security_context_t context) {
+status_t ForkExecvp(const std::vector<std::string>& args, security_context_t) {
     std::vector<std::string> output;
     size_t argc = args.size();
     char** argv = (char**)calloc(argc + 1, sizeof(char*));
@@ -237,11 +237,6 @@ status_t ForkExecvp(const std::vector<std::string>& args, security_context_t con
         } else {
             LOG(VERBOSE) << "    " << args[i];
         }
-    }
-
-    if (setexeccon(context)) {
-        LOG(ERROR) << "Failed to setexeccon";
-        abort();
     }
 
     pid_t pid = fork();
@@ -257,12 +252,7 @@ status_t ForkExecvp(const std::vector<std::string>& args, security_context_t con
 
         _exit(1);
     }
-
-    if (setexeccon(nullptr)) {
-        LOG(ERROR) << "Failed to setexeccon";
-        abort();
-    }
-
+    
     if (pid == -1) {
         PLOG(ERROR) << "Failed to exec";
         return -fork_errno;


### PR DESCRIPTION
In Xiaomi Poco F1, I was getting the following error in the logs : `Failed to setexeccon`. This made the recovery restart itself a lot of time before the it booted. Comment it out to fix the issue.

Change-Id: Id157abc3291ef20a8be0577ab3716a3d3ce6d784