### PR TITLE
Disable the unmounting of userdata during start

### DIFF
--- a/recovery.cpp
+++ b/recovery.cpp
@@ -1667,7 +1667,8 @@ static void copy_userdata_files() {
         file_copy(adb_keys_data, adb_keys_root);
       }
     }
-    ensure_path_unmounted("/data");
+    //Disabled for UBports, some devices seem to do this and then the installer copies into void
+    //ensure_path_unmounted("/data");
   }
 }
 


### PR DESCRIPTION
Some devices like Oneplus 5 seem to really unmount data with the recovery we use. The problem is that installer then cannot copy files to /data properly, and also system-image-upgrader has a hard time installing anything.
