### PR TITLE
Let emmc partitions show up in the generated fstab file

### DIFF
--- a/roots.cpp
+++ b/roots.cpp
@@ -54,7 +54,7 @@ static struct fstab* fstab = nullptr;
 extern struct selabel_handle* sehandle;
 
 static void write_fstab_entry(const Volume* v, FILE* file) {
-  if (v && strcmp(v->fs_type, "mtd") != 0 && strcmp(v->fs_type, "emmc") != 0 &&
+  if (v && strcmp(v->fs_type, "mtd") != 0 &&
       strcmp(v->fs_type, "bml") != 0 && !fs_mgr_is_voldmanaged(v) &&
       strncmp(v->blk_device, "/", 1) == 0 && strncmp(v->mount_point, "/", 1) == 0) {
     fprintf(file, "%s ", v->blk_device);


### PR DESCRIPTION
This is necessary at least for the Oneplus 5, but maybe also other devices:
- On startup, recovery constructs a generated /etc/fstab file and merges partitions from device tree with the ones from the recovery.fstab file (old style)
- It checks partition types in the recovery.fstab file - and it will skip some types that are not mountable
- system-image-upgrader however relies on the information in this file if it needs to flash boot, recovery or vendor
- Therefore, system-image-upgrader skipped at least recovery and boot partition so far on the Oneplus 5

See this line: https://github.com/ubports/halium_bootable_recovery/blob/halium-9.0/system-image-upgrader#L516-L528 - while we never gonna mount those partitions from fstab we still need them listed for flashing.
