### PR TITLE
Unify logging

### DIFF
--- a/recovery.cpp
+++ b/recovery.cpp
@@ -188,7 +188,6 @@ static const char *TEMPORARY_INSTALL_FILE = "/tmp/last_install";
 static const char *TEMPORARY_KMSG_FILE = "/tmp/last_kmsg";
 static const char *LAST_KMSG_FILE = "/cache/recovery/last_kmsg";
 static const char *LAST_LOG_FILE = "/cache/recovery/last_log";
-static const char *SYSTEM_IMAGE_UPGRADER_LOG_FILE = "/cache/system-image-upgrader.log";
 static const char *UBUNTU_UPDATER_LOG_FILE = "/cache/ubuntu_updater.log";
 // We will try to apply the update package 5 times at most in case of an I/O error or
 // bspatch | imgpatch error.
@@ -1158,11 +1157,6 @@ static int choose_recovery_file(Device* device) {
   std::vector<std::string> entries;
   if (access(TEMPORARY_LOG_FILE, R_OK) != -1) {
     entries.push_back(TEMPORARY_LOG_FILE);
-  }
-
-  // Add Ubuntu Touch specific log paths
-  if (access(SYSTEM_IMAGE_UPGRADER_LOG_FILE, R_OK) != -1) {
-    entries.push_back(SYSTEM_IMAGE_UPGRADER_LOG_FILE);
   }
 
   if (access(UBUNTU_UPDATER_LOG_FILE, R_OK) != -1) {

--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -1,6 +1,7 @@
 #!/sbin/sh
 set -e
-echo "Starting image Upgrade pre" > /cache/system-image-upgrader.log
+echo "System Image Upgrader for Ubuntu Touch"
+echo "Preparing command file"
 if [ ! -e "$1" ]; then
     echo "Command file doesn't exist: $1"
     exit 1
@@ -16,7 +17,7 @@ DATA_FORMAT=0
 # System Mountpoint
 SYSTEM_MOUNTPOINT=/cache/system
 
-echo "Starting image upgrader: $(date)" >> /cache/test.log
+echo "Starting image upgrader"
 
 # Functions
 check_filesystem() {
@@ -285,7 +286,7 @@ fi
 
 # Process the command file
 FULL_IMAGE=0
-echo "Processing the command file" >> /cache/system-image-upgrader.log
+echo "Processing command file"
 while read line
 do
     set -- $line

--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -564,14 +564,14 @@ fi
 touch /data/.last_update || true
 sync
 
-echo "Done upgrading: $(date)" >> /cache/system-image-upgrader.log
+echo "Done upgrading..."
 
 # Make sure there are always 5% reserved in /data for root usage
 # else filling $HOME can make the system unusable since writable
 # files and dirs share the space with $HOME and android does not
 # reserve root space in /data
 mount /data
-tune2fs -m 5 $(grep "/data " /proc/mounts| sed -e 's/ .*$//') >> /cache/system-image-upgrader.log
+tune2fs -m 5 $(grep "/data " /proc/mounts| sed -e 's/ .*$//')
 umount /data
 
 sync


### PR DESCRIPTION
The logging is scattered around 3 files, which was caused by sloppy commits and reverts over time. Unify the few ancient log lines into using ubuntu_updater.log, too.