### PR TITLE
Allow override of USE_SYSTEM_PARTITION

### DIFF
--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -271,7 +271,7 @@ fi
 
 # Force usage of system partition for now, the existance of Android 9.0 devices
 # with a too small system partition is questionable at this point.
-# As we speak, Google Pixel has only 2GB system partition, so lets make this overridable
+# As we speak, e.g. Google Pixel has only 2GB system partition, so lets make this overridable
 if [ -e disable_syspart ]; then
     USE_SYSTEM_PARTITION=0
 else

--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -271,7 +271,12 @@ fi
 
 # Force usage of system partition for now, the existance of Android 9.0 devices
 # with a too small system partition is questionable at this point.
-USE_SYSTEM_PARTITION=1
+# As we speak, Google Pixel has only 2GB system partition, so lets make this overridable
+if [ -e disable_syspart ]; then
+    USE_SYSTEM_PARTITION=0
+else
+    USE_SYSTEM_PARTITION=1
+fi
 
 # However, do not use the block device name in the kernel command line, as that is not consistently
 # named in booting normal and recovery modes. Expect fstab to have a system mountpoint or use a fallback.


### PR DESCRIPTION
The idea that no Android 9 device has a too small system partition is a bit flawed when it comes to devices that were just upgraded to Android 9. Like the Google Pixel, where system partition is only 2GB and Ubuntu Touch needs approx 2.5GB with embedded android image.

The flag files used here will be set in the CI pipeline and packed into the tarball for the system image server, similar to the legacy flag. Like here: https://github.com/ubports/android_bootable_recovery/blob/85ea41287b3c51fa781749c652adec182cf13e0b/system-image-upgrader#L505 and https://gitlab.com/ubports/community-ports/jenkins-ci/halium-build-tools/-/blob/main/phablet-tarball.sh#L35