### PR TITLE
system-image-upgrade: only call tune2fs for ext4 data

### DIFF
--- a/ubports/system-image-upgrader
+++ b/ubports/system-image-upgrader
@@ -586,11 +586,17 @@ echo "Done upgrading..."
 # Make sure there are always 5% reserved in /data for root usage
 # else filling $HOME can make the system unusable since writable
 # files and dirs share the space with $HOME and android does not
-# reserve root space in /data
+# reserve root space in /data for ext4.
+# Devices with f2fs can reserve space with setting the
+# "reserve_root" mount option.
 if [ "$USE_SYSTEM_PARTITION" -eq 1 ]; then
     mount /data
 fi
-tune2fs -m 5 $(grep "/data " /proc/mounts| sed -e 's/ .*$//')
+
+DATA_FS_TYPE=$(grep "/data " /proc/mounts| cut -d ' ' -f3)
+if [ "$DATA_FS_TYPE" == "ext4" ]; then
+    tune2fs -m 5 $(grep "/data " /proc/mounts| sed -e 's/ .*$//')
+fi
 
 # Always unmount unconditionally
 umount /data


### PR DESCRIPTION
Calling tune2fs on non-ext4 filesystems such as f2fs fails.
Most Android devices currently ship either ext4 or f2fs.

To reserve space for f2fs, there is a mount option "reserve_root" [1]
which allows reserving space of priviledged users.

On most of the Android devices this parameter is set as
"reserve_root=32768" in their fstab.

[1] - https://www.kernel.org/doc/Documentation/filesystems/f2fs.txt

This fixes https://github.com/ubports/halium_bootable_recovery/issues/17.