### PR TITLE
system-image-upgrader: follow symlink when extracting tarballs

### DIFF
--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -497,7 +497,9 @@ do
             fi
 
             # Unpack everything else on top of the system partition
-            busybox xzcat recovery/$2 | busybox tar --numeric-owner -xf -
+            # -h means "follow symlinks", which make device tarballs that
+            # "overlay" /lib/* work correctly with /usr-merged rootfs.
+            busybox xzcat recovery/$2 | busybox tar --numeric-owner -xhf -
             rm -f removed
 
             # WORKAROUND: fix erroneous vendor symlink


### PR DESCRIPTION
This makes device tarballs that "overlay" /lib/* work correctly with
/usr-merged rootfs.

Change-Id: I58fd63b59c9a60643ae3995aebdb1d6118cbc45b

---

@NotKit Could you please test if this works with unmodified Volla Phone X device tarball?