### PR TITLE
(ubports) init: set property to identify ubports recovery

### DIFF
--- a/etc/init.rc
+++ b/etc/init.rc
@@ -8,6 +8,9 @@ on early-init
 
     setprop sys.usb.configfs 0
 
+    # Set property to allow installers to identify recovery
+    setprop ro.ubuntu.recovery true
+
 on init
     export ANDROID_ROOT /system
     export ANDROID_DATA /data


### PR DESCRIPTION
The UBports installer has no way of knowing, if the recovery currently
used is a UBports specific recovery, which is required in order to
install Ubuntu Touch via system-image-upgrader.

Set a property which we can check for with ADB to detect if a recovery
supporting system-image-upgrader is running.

Issue: https://github.com/ubports/halium_bootable_recovery/issues/22