### PR TITLE
ubports: Filter wrongly matching partitions from upgrader

### DIFF
--- a/ubports/system-image-upgrader
+++ b/ubports/system-image-upgrader
@@ -279,7 +279,7 @@ USE_SYSTEM_PARTITION=1
 # However, do not use the block device name in the kernel command line, as that is not consistently
 # named in booting normal and recovery modes. Expect fstab to have a system mountpoint or use a fallback.
 if [ "$USE_SYSTEM_PARTITION" -eq 1 ];then
-    SYSTEM_PARTITION=$(grep "^[^#]" /etc/fstab | grep -e "\(/mnt\)*/system\(_root\)*" | cut -f 1 -d\ )
+    SYSTEM_PARTITION=$(grep "^[^#]" /etc/fstab | grep -v "/system_ext" |  grep -e "\(/mnt\)*/system\(_root\)*" | cut -f 1 -d\ )
     #Fall back to emmc@android if there's no system in fstab
     if [ "$SYSTEM_PARTITION" == "" ]; then
         SYSTEM_PARTITION="emmc@android"


### PR DESCRIPTION
/system_ext seldomly is the partition we want to flash with
a system-image, so filter it out and let the right dm-N device
take it's sole place for system-image-upgrader to do its job.

Change-Id: Ieca4e433d23574b82dc62c5368eed9dd93bfd1f5