### PR TITLE
system-image-upgrader: only flash partition images if different

### DIFF
--- a/ubports/system-image-upgrader
+++ b/ubports/system-image-upgrader
@@ -538,11 +538,18 @@ do
                 path=$1
 
                 if [ -e partitions/${part}.img ] && [ -e $path ]; then
-                    echo "Flashing ${part} at ${path}"
-                    if simgtest partitions/${part}.img; then
+                    if simgtest partitions/${part}.img 2>/dev/null; then
+                        echo "Flashing sparse ${part} at ${path}"
                         simg2img partitions/${part}.img ${path}
                     else
-                        dd bs=8M if=partitions/${part}.img of=${path}
+                        echo "Checking if ${part} at ${path} needs updating..."
+                        new_size=$(wc -c < partitions/${part}.img)
+                        if ! head -c ${new_size} ${path} | cmp -s partitions/${part}.img; then
+                            echo "  Flashing (binary content differs)..."
+                            cat partitions/${part}.img > ${path}
+                        else
+                            echo "  Already up-to-date"
+                        fi
                     fi
                     sync
                     rm partitions/${part}.img


### PR DESCRIPTION
Do this by comparing the file vs partition (up to new file size) bytes, also silence `simgtest` stderr spam on every non-sparse image file.

Log example including [`rtss`](https://github.com/freaky/rtss) timestamps to illustrate how long each step is taking on Volla Phone X23 with 20.04 OTA-2 flash to latest 20.04 devel:
```
$ rtss adb shell tail -f /cache/ubuntu_updater.log
  36.1ms   36.1ms | System Image Upgrader for Ubuntu Touch
  36.1ms          | Preparing command file
  36.1ms          | Starting image upgrader
  36.1ms          | Loading keyring: archive-master.tar.xz
 107.8ms   71.7ms | Processing command file
 111.3ms    3.5ms | Formatting: system
 274.0ms  162.7ms | system partition: /dev/block/dm-0
 312.8ms   38.8ms | umount: /mnt/system: Invalid argument
 326.1ms   13.3ms | mke2fs 1.45.4 (23-Sep-2019)
 343.8ms   17.7ms | Discarding device blocks: done                            
   1.20s    0.9ms | Creating filesystem with 2096128 4k blocks and 524288 inodes
   1.20s          | Filesystem UUID: 50e5517a-7972-45bb-975d-780492f86049
   1.20s          | Superblock backups stored on blocks: 
   1.20s          |     32768, 98304, 163840, 229376, 294912, 819200, 884736, 1605632
   1.21s    0.9ms | 
   1.21s          | Allocating group tables: done                            
   1.21s    0.7ms | Writing inode tables: done                            
   1.21s    1.2ms | Creating journal (16384 blocks): done
   1.46s  252.8ms | Writing superblocks and filesystem accounting information: done 
   1.47s    5.7ms | 
   1.47s    2.7ms | Loading keyring: image-master.tar.xz
   1.85s  379.3ms | Loading keyring: image-signing.tar.xz
   2.34s  496.1ms | umount: /dev/block/dm-0: Invalid argument
   2.38s   38.3ms | umount: /cache/system: Invalid argument
   2.42s   41.6ms | umount: /mnt/system: Invalid argument
   2.43s   10.3ms | e2fsck 1.45.4 (23-Sep-2019)
   2.44s    5.2ms | Pass 1: Checking inodes, blocks, and sizes
   2.44s    4.1ms | Pass 2: Checking directory structure
   2.44s    0.5ms | Pass 3: Checking directory connectivity
   2.44s          | Pass 4: Checking reference counts
   2.45s    9.6ms | Pass 5: Checking group summary information
   2.46s    7.9ms | /dev/block/dm-0: 11/524288 files (0.0% non-contiguous), 49303/2096128 blocks
   2.51s   44.3ms | Unknown command: 
   2.51s    0.8ms | Keyring doesn't exist: device-signing
   8.35s    5.84s | Applying update: rootfs-8c8e0801737dbb104b95b2cdecdce88ed3934b78eb4a6e3903dd1a7f709b15fd.tar.xz
 1m1.34s   52.99s | Keyring doesn't exist: device-signing
 1m5.73s    4.40s | Applying update: firmware-068a5cdbd0dcff2904fd4b771b457404fa8848063062c71a83c9178cc8dcac6e.tar.xz
1m40.56s   34.83s | Checking if vendor at /dev/block/dm-1 needs updating...
1m40.65s   84.3ms |   Flashing (binary content differs)...
1m45.51s    4.86s | Checking if lk at /dev/block/by-name/lk_a needs updating...
1m45.60s   99.1ms |   Flashing (binary content differs)...
1m45.76s  151.7ms | Checking if tee at /dev/block/by-name/tee_a needs updating...
1m45.84s   83.7ms |   Flashing (binary content differs)...
1m45.98s  142.4ms | Checking if scp at /dev/block/by-name/scp_a needs updating...
1m46.07s   87.1ms |   Flashing (binary content differs)...
1m46.21s  140.2ms | Checking if sspm at /dev/block/by-name/sspm_a needs updating...
1m46.29s   83.1ms |   Flashing (binary content differs)...
1m46.43s  135.8ms | Checking if dpm at /dev/block/by-name/dpm_a needs updating...
1m46.51s   80.3ms |   Flashing (binary content differs)...
1m46.64s  129.8ms | Checking if mcupm at /dev/block/by-name/mcupm_a needs updating...
1m46.73s   87.9ms |   Flashing (binary content differs)...
1m46.86s  131.8ms | Checking if md1img at /dev/block/by-name/md1img_a needs updating...
1m46.94s   78.5ms |   Flashing (binary content differs)...
1m47.34s  400.1ms | Checking if gz at /dev/block/by-name/gz_a needs updating...
1m47.42s   79.6ms |   Flashing (binary content differs)...
1m47.56s  138.8ms | Checking if spmfw at /dev/block/by-name/spmfw_a needs updating...
1m47.64s   81.9ms |   Flashing (binary content differs)...
1m47.76s  127.5ms | Checking if pi_img at /dev/block/by-name/pi_img_a needs updating...
1m47.85s   82.0ms |   Already up-to-date
1m48.02s  173.3ms | Keyring doesn't exist: device-signing
1m49.78s    1.76s | Applying update: device-83980d2d35082ad4f1f911079c4db009a38271327bffe0bd57388f2a31321caf.tar.xz
 2m5.23s   15.46s | Keyring doesn't exist: device-signing
 2m5.85s  615.4ms | Applying update: boot-3fe41f279fd6269ceff34f629adbb5cfcfeb46fa02271a4d05118c35be3fc2ec.tar.xz
 2m9.57s    3.72s | Checking if boot at /dev/block/by-name/boot_a needs updating...
 2m9.67s   93.2ms |   Flashing (binary content differs)...
2m11.21s    1.54s | Checking if vendor_boot at /dev/block/by-name/vendor_boot_a needs updating...
2m11.28s   74.7ms |   Flashing (binary content differs)...
2m11.45s  170.1ms | Checking if dtbo at /dev/block/by-name/dtbo_a needs updating...
2m11.53s   81.1ms |   Flashing (binary content differs)...
2m11.71s  179.0ms | Keyring doesn't exist: device-signing
2m11.73s   13.2ms | Applying update: keyring-400895c98ce498ca2d89a7ff0266361b427057d52e4be69b10118fbcbf2eef34.tar.xz
2m11.96s  235.3ms | Keyring doesn't exist: device-signing
2m11.97s   13.6ms | Applying update: version-385.tar.xz
2m12.73s  756.5ms | Done upgrading...
2m12.86s  126.9ms | tune2fs 1.45.4 (23-Sep-2019)
2m12.86s          | Setting reserved blocks percentage to 5% (645119 blocks)
2m13.91s    exit status: 0
```