### PR TITLE
[Halium 9] system-image-upgrader: Wipe .fscrypt directory properly

### DIFF
--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -315,7 +315,7 @@ do
 
                 data)
                     mount /data || true
-                    for entry in /data/* /data/.writable_image /data/.factory_wipe; do
+                    for entry in /data/* /data/.writable_image /data/.factory_wipe /data/.fscrypt; do
                         if [ "$USE_SYSTEM_PARTITION" -eq 0 ]; then
                             if [[ ( "$entry" == "/data/ubuntu.img" ) || ( "$entry" == "/data/rootfs.img" ) || ( "$entry" == "/data/system.img" ) || ( "$entry" == "/data/android-rootfs.img" ) ]]; then
                                     continue


### PR DESCRIPTION
We can't have old protectors and policies stay around on-disk after a wipe, otherwise fscrypt setup would use the old PIN.