### PR TITLE
[halium-14.0] Ship servicemanager.recovery to fix FastbootD 

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -193,6 +193,7 @@ cc_binary {
         "mkshrc.recovery",
         "reboot.recovery",
         "recovery_deps",
+        "servicemanager.recovery",
         "ueventd.rc.recovery",
 
         // ubports


### PR DESCRIPTION
Otherwise it'll be stuck indefinitely:
```
[  153.006143][    T1] init: processing action (sys.usb.config=fastboot) from (/system/etc/init/hw/init.rc:193)
[  154.031005][T601189] ServiceManagerCppClient: Waited for servicemanager.ready for a second, waiting another...
[  155.031433][T601189] ServiceManagerCppClient: Waited for servicemanager.ready for a second, waiting another...
...
```