### PR TITLE
[halium-14.0] Support QTI DRM rendering backend

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -9,7 +9,32 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+________________________________________________________________________________
 
+  DRM based mode setting test program
+  Copyright 2008 Tungsten Graphics
+    Jakob Bornecrantz <jakob@tungstengraphics.com>
+  Copyright 2008 Intel Corporation
+    Jesse Barnes <jesse.barnes@intel.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+________________________________________________________________________________
 
                                  Apache License
                            Version 2.0, January 2004

--- a/minui/Android.bp
+++ b/minui/Android.bp
@@ -64,9 +64,4 @@ cc_library {
             ],
         },
     },
-
-    cflags: select(soong_config_variable("recovery", "target_recovery_uses_qti_drm"), {
-        true: ["-DTARGET_RECOVERY_USES_QTI_DRM"],
-        default: [],
-    }),
 }

--- a/minui/Android.bp
+++ b/minui/Android.bp
@@ -38,6 +38,7 @@ cc_library {
         "events.cpp",
         "graphics.cpp",
         "graphics_drm.cpp",
+        "graphics_drm_qti.cpp",
         "graphics_fbdev.cpp",
         "resources.cpp",
     ],
@@ -63,4 +64,9 @@ cc_library {
             ],
         },
     },
+
+    cflags: select(soong_config_variable("recovery", "target_recovery_uses_qti_drm"), {
+        true: ["-DTARGET_RECOVERY_USES_QTI_DRM"],
+        default: [],
+    }),
 }

--- a/minui/graphics.cpp
+++ b/minui/graphics.cpp
@@ -26,6 +26,7 @@
 #include <android-base/properties.h>
 
 #include "graphics_drm.h"
+#include "graphics_drm_qti.h"
 #include "graphics_fbdev.h"
 #include "minui/minui.h"
 
@@ -396,7 +397,11 @@ void gr_flip() {
 std::unique_ptr<MinuiBackend> create_backend(GraphicsBackend backend) {
   switch (backend) {
     case GraphicsBackend::DRM:
+#ifdef TARGET_RECOVERY_USES_QTI_DRM
+      return std::make_unique<MinuiBackendDrmQti>();
+#else
       return std::make_unique<MinuiBackendDrm>();
+#endif
     case GraphicsBackend::FBDEV:
       return std::make_unique<MinuiBackendFbdev>();
     default:

--- a/minui/graphics.cpp
+++ b/minui/graphics.cpp
@@ -395,13 +395,15 @@ void gr_flip() {
 }
 
 std::unique_ptr<MinuiBackend> create_backend(GraphicsBackend backend) {
+  bool is_qcom_hw = (android::base::GetProperty("ro.hardware", "") == "qcom");
+  bool use_qti_drm = android::base::GetBoolProperty("ro.minui.use_qti_drm", is_qcom_hw);
   switch (backend) {
     case GraphicsBackend::DRM:
-#ifdef TARGET_RECOVERY_USES_QTI_DRM
-      return std::make_unique<MinuiBackendDrmQti>();
-#else
-      return std::make_unique<MinuiBackendDrm>();
-#endif
+      if (use_qti_drm) {
+        return std::make_unique<MinuiBackendDrmQti>();
+      } else {
+        return std::make_unique<MinuiBackendDrm>();
+      }
     case GraphicsBackend::FBDEV:
       return std::make_unique<MinuiBackendFbdev>();
     default:

--- a/minui/graphics_drm_qti.cpp
+++ b/minui/graphics_drm_qti.cpp
@@ -59,6 +59,8 @@
 #include <drm_fourcc.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
+#include <sstream>
+#include <string>
 
 #include "minui/minui.h"
 
@@ -81,6 +83,54 @@
 #define add_prop(res, type, Type, id, id_name, id_val, index) \
   find_prop_id(res, type, Type, id, id_name, prop_id, index); \
   if (prop_id) drmModeAtomicAddProperty(atomic_req, id, prop_id, id_val);
+
+/**
+ * enum sde_rm_topology_name - HW resource use case in use by connector
+ * @SDE_RM_TOPOLOGY_NONE:                 No topology in use currently
+ * @SDE_RM_TOPOLOGY_SINGLEPIPE:           1 LM, 1 PP, 1 INTF/WB
+ * @SDE_RM_TOPOLOGY_SINGLEPIPE_DSC:       1 LM, 1 DSC, 1 PP, 1 INTF/WB
+ * @SDE_RM_TOPOLOGY_DUALPIPE:             2 LM, 2 PP, 2 INTF/WB
+ * @SDE_RM_TOPOLOGY_DUALPIPE_DSC:         2 LM, 2 DSC, 2 PP, 2 INTF/WB
+ * @SDE_RM_TOPOLOGY_DUALPIPE_3DMERGE:     2 LM, 2 PP, 3DMux, 1 INTF/WB
+ * @SDE_RM_TOPOLOGY_DUALPIPE_3DMERGE_DSC: 2 LM, 2 PP, 3DMux, 1 DSC, 1 INTF/WB
+ * @SDE_RM_TOPOLOGY_DUALPIPE_DSCMERGE:    2 LM, 2 PP, 2 DSC Merge, 1 INTF/WB
+ * @SDE_RM_TOPOLOGY_PPSPLIT:              1 LM, 2 PPs, 2 INTF/WB
+ */
+
+static uint32_t get_lm_number(const std::string& topology) {
+  if (topology == "sde_singlepipe") return 1;
+  if (topology == "sde_singlepipe_dsc") return 1;
+  if (topology == "sde_dualpipe") return 2;
+  if (topology == "sde_dualpipe_dsc") return 2;
+  if (topology == "sde_dualpipemerge") return 2;
+  if (topology == "sde_dualpipemerge_dsc") return 2;
+  if (topology == "sde_dualpipe_dscmerge") return 2;
+  if (topology == "sde_ppsplit") return 1;
+  return 2;
+}
+
+static uint32_t get_topology_lm_number(int fd, uint32_t blob_id) {
+  uint32_t num_lm = 2;
+
+  drmModePropertyBlobRes* blob = drmModeGetPropertyBlob(fd, blob_id);
+  if (!blob) {
+    return num_lm;
+  }
+
+  const char* fmt_str = (const char*)(blob->data);
+  std::stringstream stream(fmt_str);
+  std::string line = {};
+  const std::string topology = "topology=";
+
+  while (std::getline(stream, line)) {
+    if (line.find(topology) != std::string::npos) {
+      num_lm = get_lm_number(std::string(line, topology.length()));
+    }
+  }
+
+  drmModeFreePropertyBlob(blob);
+  return num_lm;
+}
 
 static int find_plane_prop_id(uint32_t obj_id, const char* prop_name, Plane* plane_res) {
   int i, j = 0;
@@ -125,18 +175,18 @@ int MinuiBackendDrmQti::AtomicPopulatePlane(int plane, drmModeAtomicReqPtr atomi
   int height = drm[index].monitor_crtc->mode.vdisplay;
 
   src_y = 0;
-  src_w = width / 2;
+  src_w = width / number_of_lms;
   src_h = height;
   crtc_y = 0;
-  crtc_w = width / 2;
+  crtc_w = width / number_of_lms;
   crtc_h = height;
 
   if (plane == Left) {
     src_x = 0;
     crtc_x = 0;
   } else {
-    src_x = width / 2;
-    crtc_x = width / 2;
+    src_x = width / number_of_lms;
+    crtc_x = width / number_of_lms;
   }
 
   if (atomic_add_prop_to_plane(plane_res, atomic_req, plane_res[plane].plane->plane_id, "FB_ID",
@@ -183,8 +233,8 @@ int MinuiBackendDrmQti::AtomicPopulatePlane(int plane, drmModeAtomicReqPtr atomi
 }
 
 int MinuiBackendDrmQti::TeardownPipeline(drmModeAtomicReqPtr atomic_req, DrmConnector index) {
-  uint32_t prop_id;
-  int i, ret;
+  uint32_t i, prop_id;
+  int ret;
 
   /* During suspend, tear down pipeline */
   add_prop(&conn_res, connector, Connector, drm[index].monitor_connector->connector_id, "CRTC_ID",
@@ -192,7 +242,7 @@ int MinuiBackendDrmQti::TeardownPipeline(drmModeAtomicReqPtr atomic_req, DrmConn
   add_prop(&crtc_res, crtc, Crtc, drm[index].monitor_crtc->crtc_id, "MODE_ID", 0, index);
   add_prop(&crtc_res, crtc, Crtc, drm[index].monitor_crtc->crtc_id, "ACTIVE", 0, index);
 
-  for (i = 0; i < NUM_PLANES; i++) {
+  for (i = 0; i < number_of_lms; i++) {
     ret =
         atomic_add_prop_to_plane(plane_res, atomic_req, plane_res[i].plane->plane_id, "CRTC_ID", 0);
     if (ret < 0) {
@@ -210,10 +260,10 @@ int MinuiBackendDrmQti::TeardownPipeline(drmModeAtomicReqPtr atomic_req, DrmConn
 }
 
 int MinuiBackendDrmQti::SetupPipeline(drmModeAtomicReqPtr atomic_req, DrmConnector index) {
-  uint32_t prop_id;
-  int i, ret;
+  uint32_t i, prop_id;
+  int ret;
 
-  for (i = 0; i < NUM_PLANES; i++) {
+  for (i = 0; i < number_of_lms; i++) {
     add_prop(&conn_res, connector, Connector, drm[index].monitor_connector->connector_id, "CRTC_ID",
              drm[index].monitor_crtc->crtc_id, index);
     add_prop(&crtc_res, crtc, Crtc, drm[index].monitor_crtc->crtc_id, "MODE_ID",
@@ -222,7 +272,7 @@ int MinuiBackendDrmQti::SetupPipeline(drmModeAtomicReqPtr atomic_req, DrmConnect
   }
 
   /* Setup planes */
-  for (i = 0; i < NUM_PLANES; i++) {
+  for (i = 0; i < number_of_lms; i++) {
     ret = AtomicPopulatePlane(i, atomic_req, index);
     if (ret < 0) {
       printf("Error populating plane_id = %d\n", plane_res[i].plane->plane_id);
@@ -544,7 +594,7 @@ void MinuiBackendDrmQti::DisableNonMainCrtcs(int fd, drmModeRes* resources,
 }
 
 void MinuiBackendDrmQti::UpdatePlaneFB(DrmConnector index) {
-  int i;
+  uint32_t i;
 
   /* Set atomic req */
   drmModeAtomicReqPtr atomic_req = drmModeAtomicAlloc();
@@ -554,7 +604,7 @@ void MinuiBackendDrmQti::UpdatePlaneFB(DrmConnector index) {
   }
 
   /* Add property */
-  for (i = 0; i < NUM_PLANES; i++)
+  for (i = 0; i < number_of_lms; i++)
     drmModeAtomicAddProperty(atomic_req, plane_res[i].plane->plane_id, fb_prop_id,
                              drm[index].GRSurfaceDrms[drm[index].current_buffer]->fb_id);
 
@@ -571,6 +621,7 @@ GRSurface* MinuiBackendDrmQti::Init() {
   drmModeRes* res = nullptr;
   drm_fd = -1;
 
+  number_of_lms = 2;
   /* Consider DRM devices in order. */
   for (int i = 0; i < DRM_MAX_MINOR; i++) {
     auto dev_name = android::base::StringPrintf(DRM_DEV_NAME, DRM_DIR_NAME, i);
@@ -642,7 +693,7 @@ GRSurface* MinuiBackendDrmQti::Init() {
 
   /* Get possible plane_ids */
   drmModePlaneRes* plane_options = drmModeGetPlaneResources(drm_fd);
-  if (!plane_options || !plane_options->planes || (plane_options->count_planes < NUM_PLANES))
+  if (!plane_options || !plane_options->planes || (plane_options->count_planes < number_of_lms))
     return NULL;
 
   drmSetClientCap(drm_fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
@@ -670,17 +721,24 @@ GRSurface* MinuiBackendDrmQti::Init() {
       calloc(conn_res.props->count_props, sizeof(conn_res.props_info)));
   if (!conn_res.props_info)
     return NULL;
-  else
-    for (int j = 0; j < (int)conn_res.props->count_props; ++j)
+  else {
+    for (int j = 0; j < (int)conn_res.props->count_props; ++j) {
       conn_res.props_info[j] = drmModeGetProperty(drm_fd, conn_res.props->props[j]);
 
+      if (!strcmp(conn_res.props_info[j]->name, "mode_properties")) {
+        number_of_lms = get_topology_lm_number(drm_fd, conn_res.props->prop_values[j]);
+        printf("number of lms in topology %d\n", number_of_lms);
+      }
+    }
+  }
+
   /* Set plane resources */
-  for (int i = 0; i < NUM_PLANES; ++i) {
+  for (uint32_t i = 0; i < number_of_lms; ++i) {
     plane_res[i].plane = drmModeGetPlane(drm_fd, plane_options->planes[i]);
     if (!plane_res[i].plane) return NULL;
   }
 
-  for (int i = 0; i < NUM_PLANES; ++i) {
+  for (uint32_t i = 0; i < number_of_lms; ++i) {
     struct Plane* obj = &plane_res[i];
     unsigned int j;
     obj->props = drmModeObjectGetProperties(drm_fd, obj->plane->plane_id, DRM_MODE_OBJECT_PLANE);

--- a/minui/graphics_drm_qti.cpp
+++ b/minui/graphics_drm_qti.cpp
@@ -54,6 +54,7 @@
 #include <memory>
 
 #include <android-base/macros.h>
+#include <android-base/properties.h>
 #include <android-base/stringprintf.h>
 #include <android-base/unique_fd.h>
 #include <drm_fourcc.h>
@@ -181,6 +182,98 @@ static int atomic_add_prop_to_plane(Plane* plane_res, drmModeAtomicReq* req, uin
   return 0;
 }
 
+static int SetupSprBlobV1(int fd, uint32_t* blob_id) {
+  SPRPackType pack_type = SPRPackType::kPentile;
+  SPRFilterType filter_type = SPRFilterType::kFourTap;
+  SPRAdaptiveModeType adpative_mode = SPRAdaptiveModeType::kYYGM;
+
+  drm_msm_spr_init_cfg spr_init_cfg;
+  spr_init_cfg.cfg0 = 1;
+  spr_init_cfg.cfg1 = 1;
+  spr_init_cfg.cfg2 = 1;
+  spr_init_cfg.cfg3 = 0;
+  spr_init_cfg.flags = 0;
+  spr_init_cfg.cfg4 = (pack_type == SPRPackType::kRGBW);
+  spr_init_cfg.cfg5 = kDefaultColorPhaseIncrement.at(pack_type);
+  spr_init_cfg.cfg6 = kDefaultColorPhaseRepeat.at(pack_type);
+  spr_init_cfg.cfg7 = static_cast<uint16_t>(filter_type);
+  spr_init_cfg.cfg8 = static_cast<uint16_t>(adpative_mode);
+  if (pack_type == SPRPackType::kRGBW) {
+    spr_init_cfg.cfg9 = 512;
+    std::copy(kDefaultRGBWGains.begin(), kDefaultRGBWGains.end(), spr_init_cfg.cfg11);
+  }
+  spr_init_cfg.cfg10 = 0;
+  std::copy(kDecimationRatioMap.at(pack_type).begin(), kDecimationRatioMap.at(pack_type).end(),
+            spr_init_cfg.cfg11);
+  std::copy(kDefaultOPRGains.begin(), kDefaultOPRGains.end(), spr_init_cfg.cfg13);
+  std::copy(kDefaultAdaptiveStrengths.begin(), kDefaultAdaptiveStrengths.end(), spr_init_cfg.cfg14);
+  std::copy(kDefaultOPROffsets.begin(), kDefaultOPROffsets.end(), spr_init_cfg.cfg15);
+  std::copy(kDefaultFilterCoeffsMap.at(filter_type).begin(),
+            kDefaultFilterCoeffsMap.at(filter_type).end(), spr_init_cfg.cfg16);
+  std::copy(kDefaultColorPhaseMap.at(pack_type).begin(), kDefaultColorPhaseMap.at(pack_type).end(),
+            spr_init_cfg.cfg17);
+
+  if (drmModeCreatePropertyBlob(fd, &spr_init_cfg, sizeof(drm_msm_spr_init_cfg), blob_id)) {
+    printf("failed to create spr blob\n");
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+static int SetupSprBlobV2(int fd, uint32_t* blob_id) {
+  SPRPackType pack_type = SPRPackType::kPentile;
+  SPRFilterType filter_type = SPRFilterType::kFourTap;
+  SPRAdaptiveModeType adpative_mode = SPRAdaptiveModeType::kYYGM;
+
+  drm_msm_spr_init_cfg_v2 spr_init_cfg_v2;
+  spr_init_cfg_v2.cfg0 = 1;
+  spr_init_cfg_v2.cfg1 = 1;
+  spr_init_cfg_v2.cfg2 = 1;
+  spr_init_cfg_v2.cfg3 = 0;
+  spr_init_cfg_v2.flags = 0;
+  spr_init_cfg_v2.cfg4 = (pack_type == SPRPackType::kRGBW);
+  spr_init_cfg_v2.cfg5 = kDefaultColorPhaseIncrement.at(pack_type);
+  spr_init_cfg_v2.cfg6 = kDefaultColorPhaseRepeat.at(pack_type);
+  spr_init_cfg_v2.cfg7 = static_cast<uint16_t>(filter_type);
+  spr_init_cfg_v2.cfg8 = static_cast<uint16_t>(adpative_mode);
+  if (pack_type == SPRPackType::kRGBW) {
+    spr_init_cfg_v2.cfg9 = 512;
+    std::copy(kDefaultRGBWGains.begin(), kDefaultRGBWGains.end(), spr_init_cfg_v2.cfg11);
+  }
+  spr_init_cfg_v2.cfg10 = 0;
+  std::copy(kDecimationRatioMap.at(pack_type).begin(), kDecimationRatioMap.at(pack_type).end(),
+            spr_init_cfg_v2.cfg11);
+  std::copy(kDefaultOPRGains.begin(), kDefaultOPRGains.end(), spr_init_cfg_v2.cfg13);
+  std::copy(kDefaultAdaptiveStrengths.begin(), kDefaultAdaptiveStrengths.end(),
+            spr_init_cfg_v2.cfg14);
+  std::copy(kDefaultOPROffsets.begin(), kDefaultOPROffsets.end(), spr_init_cfg_v2.cfg15);
+  std::copy(kDefaultFilterCoeffsMap.at(filter_type).begin(),
+            kDefaultFilterCoeffsMap.at(filter_type).end(), spr_init_cfg_v2.cfg16);
+  std::copy(kDefaultColorPhaseMap.at(pack_type).begin(), kDefaultColorPhaseMap.at(pack_type).end(),
+            spr_init_cfg_v2.cfg17);
+
+  if (drmModeCreatePropertyBlob(fd, &spr_init_cfg_v2, sizeof(drm_msm_spr_init_cfg_v2), blob_id)) {
+    printf("failed to create spr blob\n");
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+static int SetupSprBlob(int fd, const std::string& prop_name, uint32_t* blob_id) {
+  int ret = 0;
+  if (prop_name == "SDE_SPR_INIT_CFG_V1") {
+    ret = SetupSprBlobV1(fd, blob_id);
+  } else if (prop_name == "SDE_SPR_INIT_CFG_V2") {
+    ret = SetupSprBlobV2(fd, blob_id);
+  } else {
+    ret = -ENOENT;
+  }
+
+  return ret;
+}
+
 int MinuiBackendDrmQti::AtomicPopulatePlane(int plane, drmModeAtomicReqPtr atomic_req,
                                             DrmConnector index) {
   uint32_t src_x, src_y, src_w, src_h;
@@ -255,6 +348,10 @@ int MinuiBackendDrmQti::TeardownPipeline(drmModeAtomicReqPtr atomic_req, DrmConn
            0, index);
   add_prop(&crtc_res, crtc, Crtc, drm[index].monitor_crtc->crtc_id, "MODE_ID", 0, index);
   add_prop(&crtc_res, crtc, Crtc, drm[index].monitor_crtc->crtc_id, "ACTIVE", 0, index);
+  if (spr_enabled) {
+    add_prop(&crtc_res, crtc, Crtc, drm[index].monitor_crtc->crtc_id, spr_prop_name.c_str(), 0,
+             index);
+  }
 
   for (i = 0; i < number_of_lms; i++) {
     ret =
@@ -283,6 +380,10 @@ int MinuiBackendDrmQti::SetupPipeline(drmModeAtomicReqPtr atomic_req, DrmConnect
     add_prop(&crtc_res, crtc, Crtc, drm[index].monitor_crtc->crtc_id, "MODE_ID",
              crtc_res.mode_blob_id, index);
     add_prop(&crtc_res, crtc, Crtc, drm[index].monitor_crtc->crtc_id, "ACTIVE", 1, index);
+    if (spr_enabled) {
+      add_prop(&crtc_res, crtc, Crtc, drm[index].monitor_crtc->crtc_id, spr_prop_name.c_str(),
+               crtc_res.spr_blob_id, index);
+    }
   }
 
   /* Setup planes */
@@ -641,6 +742,7 @@ GRSurface* MinuiBackendDrmQti::Init() {
   drmModeRes* res = nullptr;
   drm_fd = -1;
 
+  spr_enabled = android::base::GetIntProperty("vendor.display.enable_spr", 0);
   number_of_lms = DEFAULT_NUM_LMS;
   /* Consider DRM devices in order. */
   for (int i = 0; i < DRM_MAX_MINOR; i++) {
@@ -729,8 +831,14 @@ GRSurface* MinuiBackendDrmQti::Init() {
   if (!crtc_res.props_info)
     return NULL;
   else
-    for (int j = 0; j < (int)crtc_res.props->count_props; ++j)
+    for (int j = 0; j < (int)crtc_res.props->count_props; ++j) {
       crtc_res.props_info[j] = drmModeGetProperty(drm_fd, crtc_res.props->props[j]);
+      /* Get spr property name */
+      if (!strcmp(crtc_res.props_info[j]->name, "SDE_SPR_INIT_CFG_V1") ||
+          !strcmp(crtc_res.props_info[j]->name, "SDE_SPR_INIT_CFG_V2")) {
+        spr_prop_name = crtc_res.props_info[j]->name;
+      }
+    }
 
   /* Set connector resources */
   conn_res.props = drmModeObjectGetProperties(drm_fd, drm[DRM_MAIN].monitor_connector->connector_id,
@@ -781,6 +889,13 @@ GRSurface* MinuiBackendDrmQti::Init() {
                                 &crtc_res.mode_blob_id)) {
     printf("failed to create mode blob\n");
     return NULL;
+  }
+
+  /* Setup spr blob id if enabled */
+  if (spr_enabled) {
+    if (SetupSprBlob(drm_fd, spr_prop_name, &crtc_res.spr_blob_id)) {
+      return NULL;
+    }
   }
 
   /* Save fb_prop_id*/

--- a/minui/graphics_drm_qti.cpp
+++ b/minui/graphics_drm_qti.cpp
@@ -14,8 +14,35 @@
  * limitations under the License.
  */
 
+/*
+ * DRM based mode setting test program
+ * Copyright 2008 Tungsten Graphics
+ *   Jakob Bornecrantz <jakob@tungstengraphics.com>
+ * Copyright 2008 Intel Corporation
+ *   Jesse Barnes <jesse.barnes@intel.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
 #include "graphics_drm_qti.h"
 
+#include <errno.h>
 #include <fcntl.h>
 #include <poll.h>
 #include <stdio.h>
@@ -34,6 +61,177 @@
 #include <xf86drmMode.h>
 
 #include "minui/minui.h"
+
+#define find_prop_id(_res, type, Type, obj_id, prop_name, prop_id, index) \
+  do {                                                                    \
+    int j = 0;                                                            \
+    int prop_count = 0;                                                   \
+    struct Type* obj = NULL;                                              \
+    obj = (_res);                                                         \
+    if (!obj || drm[index].monitor_##type->type##_id != (obj_id)) {       \
+      prop_id = 0;                                                        \
+      break;                                                              \
+    }                                                                     \
+    prop_count = (int)obj->props->count_props;                            \
+    for (j = 0; j < prop_count; ++j)                                      \
+      if (!strcmp(obj->props_info[j]->name, (prop_name))) break;          \
+    (prop_id) = (j == prop_count) ? 0 : obj->props_info[j]->prop_id;      \
+  } while (0)
+
+#define add_prop(res, type, Type, id, id_name, id_val, index) \
+  find_prop_id(res, type, Type, id, id_name, prop_id, index); \
+  if (prop_id) drmModeAtomicAddProperty(atomic_req, id, prop_id, id_val);
+
+static int find_plane_prop_id(uint32_t obj_id, const char* prop_name, Plane* plane_res) {
+  int i, j = 0;
+  int prop_count = 0;
+  struct Plane* obj = NULL;
+
+  for (i = 0; i < NUM_PLANES; ++i) {
+    obj = &plane_res[i];
+    if (!obj || obj->plane->plane_id != obj_id) continue;
+    prop_count = (int)obj->props->count_props;
+    for (j = 0; j < prop_count; ++j)
+      if (!strcmp(obj->props_info[j]->name, prop_name)) return obj->props_info[j]->prop_id;
+    break;
+  }
+
+  return 0;
+}
+
+static int atomic_add_prop_to_plane(Plane* plane_res, drmModeAtomicReq* req, uint32_t obj_id,
+                                    const char* prop_name, uint64_t value) {
+  uint32_t prop_id;
+
+  prop_id = find_plane_prop_id(obj_id, prop_name, plane_res);
+  if (prop_id == 0) {
+    printf("Could not find obj_id = %d\n", obj_id);
+    return -EINVAL;
+  }
+
+  if (drmModeAtomicAddProperty(req, obj_id, prop_id, value) < 0) {
+    printf("Could not add prop_id = %d for obj_id %d\n", prop_id, obj_id);
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+int MinuiBackendDrmQti::AtomicPopulatePlane(int plane, drmModeAtomicReqPtr atomic_req,
+                                            DrmConnector index) {
+  uint32_t src_x, src_y, src_w, src_h;
+  uint32_t crtc_x, crtc_y, crtc_w, crtc_h;
+  int width = drm[index].monitor_crtc->mode.hdisplay;
+  int height = drm[index].monitor_crtc->mode.vdisplay;
+
+  src_y = 0;
+  src_w = width / 2;
+  src_h = height;
+  crtc_y = 0;
+  crtc_w = width / 2;
+  crtc_h = height;
+
+  if (plane == Left) {
+    src_x = 0;
+    crtc_x = 0;
+  } else {
+    src_x = width / 2;
+    crtc_x = width / 2;
+  }
+
+  if (atomic_add_prop_to_plane(plane_res, atomic_req, plane_res[plane].plane->plane_id, "FB_ID",
+                               drm[index].GRSurfaceDrms[drm[index].current_buffer]->fb_id))
+    return -EINVAL;
+
+  if (atomic_add_prop_to_plane(plane_res, atomic_req, plane_res[plane].plane->plane_id, "SRC_X",
+                               src_x << 16))
+    return -EINVAL;
+
+  if (atomic_add_prop_to_plane(plane_res, atomic_req, plane_res[plane].plane->plane_id, "SRC_Y",
+                               src_y << 16))
+    return -EINVAL;
+
+  if (atomic_add_prop_to_plane(plane_res, atomic_req, plane_res[plane].plane->plane_id, "SRC_W",
+                               src_w << 16))
+    return -EINVAL;
+
+  if (atomic_add_prop_to_plane(plane_res, atomic_req, plane_res[plane].plane->plane_id, "SRC_H",
+                               src_h << 16))
+    return -EINVAL;
+
+  if (atomic_add_prop_to_plane(plane_res, atomic_req, plane_res[plane].plane->plane_id, "CRTC_X",
+                               crtc_x))
+    return -EINVAL;
+
+  if (atomic_add_prop_to_plane(plane_res, atomic_req, plane_res[plane].plane->plane_id, "CRTC_Y",
+                               crtc_y))
+    return -EINVAL;
+
+  if (atomic_add_prop_to_plane(plane_res, atomic_req, plane_res[plane].plane->plane_id, "CRTC_W",
+                               crtc_w))
+    return -EINVAL;
+
+  if (atomic_add_prop_to_plane(plane_res, atomic_req, plane_res[plane].plane->plane_id, "CRTC_H",
+                               crtc_h))
+    return -EINVAL;
+
+  if (atomic_add_prop_to_plane(plane_res, atomic_req, plane_res[plane].plane->plane_id, "CRTC_ID",
+                               drm[index].monitor_crtc->crtc_id))
+    return -EINVAL;
+
+  return 0;
+}
+
+int MinuiBackendDrmQti::TeardownPipeline(drmModeAtomicReqPtr atomic_req, DrmConnector index) {
+  uint32_t prop_id;
+  int i, ret;
+
+  /* During suspend, tear down pipeline */
+  add_prop(&conn_res, connector, Connector, drm[index].monitor_connector->connector_id, "CRTC_ID",
+           0, index);
+  add_prop(&crtc_res, crtc, Crtc, drm[index].monitor_crtc->crtc_id, "MODE_ID", 0, index);
+  add_prop(&crtc_res, crtc, Crtc, drm[index].monitor_crtc->crtc_id, "ACTIVE", 0, index);
+
+  for (i = 0; i < NUM_PLANES; i++) {
+    ret =
+        atomic_add_prop_to_plane(plane_res, atomic_req, plane_res[i].plane->plane_id, "CRTC_ID", 0);
+    if (ret < 0) {
+      printf("Failed to tear down plane %d\n", i);
+      return ret;
+    }
+
+    if (drmModeAtomicAddProperty(atomic_req, plane_res[i].plane->plane_id, fb_prop_id, 0) < 0) {
+      printf("Failed to add property for plane_id=%d\n", plane_res[i].plane->plane_id);
+      return -EINVAL;
+    }
+  }
+
+  return 0;
+}
+
+int MinuiBackendDrmQti::SetupPipeline(drmModeAtomicReqPtr atomic_req, DrmConnector index) {
+  uint32_t prop_id;
+  int i, ret;
+
+  for (i = 0; i < NUM_PLANES; i++) {
+    add_prop(&conn_res, connector, Connector, drm[index].monitor_connector->connector_id, "CRTC_ID",
+             drm[index].monitor_crtc->crtc_id, index);
+    add_prop(&crtc_res, crtc, Crtc, drm[index].monitor_crtc->crtc_id, "MODE_ID",
+             crtc_res.mode_blob_id, index);
+    add_prop(&crtc_res, crtc, Crtc, drm[index].monitor_crtc->crtc_id, "ACTIVE", 1, index);
+  }
+
+  /* Setup planes */
+  for (i = 0; i < NUM_PLANES; i++) {
+    ret = AtomicPopulatePlane(i, atomic_req, index);
+    if (ret < 0) {
+      printf("Error populating plane_id = %d\n", plane_res[i].plane->plane_id);
+      return ret;
+    }
+  }
+
+  return 0;
+}
 
 GRSurfaceDrmQti::~GRSurfaceDrmQti() {
   if (mmapped_buffer_) {
@@ -143,28 +341,12 @@ std::unique_ptr<GRSurfaceDrmQti> GRSurfaceDrmQti::Create(int drm_fd, int width, 
   return surface;
 }
 
-void MinuiBackendDrmQti::DrmDisableCrtc(int drm_fd, drmModeCrtc* crtc) {
-  if (crtc) {
-    drmModeSetCrtc(drm_fd, crtc->crtc_id,
-                   0,         // fb_id
-                   0, 0,      // x,y
-                   nullptr,   // connectors
-                   0,         // connector_count
-                   nullptr);  // mode
-  }
+int MinuiBackendDrmQti::DrmDisableCrtc(drmModeAtomicReqPtr atomic_req, DrmConnector index) {
+  return TeardownPipeline(atomic_req, index);
 }
 
-bool MinuiBackendDrmQti::DrmEnableCrtc(int drm_fd, drmModeCrtc* crtc,
-                                       const std::unique_ptr<GRSurfaceDrmQti>& surface,
-                                       uint32_t* connector_id) {
-  if (drmModeSetCrtc(drm_fd, crtc->crtc_id, surface->fb_id, 0, 0,  // x,y
-                     connector_id, 1,                              // connector_count
-                     &crtc->mode) != 0) {
-    fprintf(stderr, "Failed to drmModeSetCrtc(%d)\n", *connector_id);
-    return false;
-  }
-
-  return true;
+int MinuiBackendDrmQti::DrmEnableCrtc(drmModeAtomicReqPtr atomic_req, DrmConnector index) {
+  return SetupPipeline(atomic_req, index);
 }
 
 void MinuiBackendDrmQti::Blank(bool blank) {
@@ -191,15 +373,29 @@ void MinuiBackendDrmQti::Blank(bool blank, DrmConnector index) {
     return;
   }
 
-  if (blank) {
-    DrmDisableCrtc(drm_fd, drmInterface->monitor_crtc);
-  } else {
-    DrmEnableCrtc(drm_fd, drmInterface->monitor_crtc,
-                  drmInterface->GRSurfaceDrms[drmInterface->current_buffer],
-                  &drmInterface->monitor_connector->connector_id);
+  int ret = 0;
 
-    active_display = index;
+  if (blank == current_blank_state) return;
+
+  drmModeAtomicReqPtr atomic_req = drmModeAtomicAlloc();
+  if (!atomic_req) {
+    printf("Atomic Alloc failed\n");
+    return;
   }
+
+  if (blank)
+    ret = DrmDisableCrtc(atomic_req, index);
+  else
+    ret = DrmEnableCrtc(atomic_req, index);
+
+  if (!ret) ret = drmModeAtomicCommit(drm_fd, atomic_req, DRM_MODE_ATOMIC_ALLOW_MODESET, NULL);
+
+  if (!ret) {
+    printf("Atomic Commit failed, rc = %d\n", ret);
+    current_blank_state = blank;
+  }
+
+  drmModeAtomicFree(atomic_req);
 }
 
 bool MinuiBackendDrmQti::HasMultipleConnectors() {
@@ -323,14 +519,52 @@ bool MinuiBackendDrmQti::FindAndSetMonitor(int fd, drmModeRes* resources) {
 
 void MinuiBackendDrmQti::DisableNonMainCrtcs(int fd, drmModeRes* resources,
                                              drmModeCrtc* main_crtc) {
+  uint32_t prop_id;
+  drmModeAtomicReqPtr atomic_req = drmModeAtomicAlloc();
+
   for (int i = 0; i < resources->count_connectors; i++) {
     drmModeConnector* connector = drmModeGetConnector(fd, resources->connectors[i]);
     drmModeCrtc* crtc = find_crtc_for_connector(fd, resources, connector);
     if (crtc->crtc_id != main_crtc->crtc_id) {
-      DrmDisableCrtc(fd, crtc);
+      // Switching to atomic commit. Given only crtc, we can only set ACTIVE = 0
+      // to disable any Nonmain CRTCs
+      find_prop_id(&crtc_res, crtc, Crtc, crtc->crtc_id, "ACTIVE", prop_id, i);
+      if (prop_id == 0) return;
+
+      if (drmModeAtomicAddProperty(atomic_req, drm[i].monitor_crtc->crtc_id, prop_id, 0) < 0)
+        return;
     }
     drmModeFreeCrtc(crtc);
   }
+
+  if (!drmModeAtomicCommit(drm_fd, atomic_req, DRM_MODE_ATOMIC_ALLOW_MODESET, NULL))
+    printf("Atomic Commit failed in DisableNonMainCrtcs\n");
+
+  drmModeAtomicFree(atomic_req);
+}
+
+void MinuiBackendDrmQti::UpdatePlaneFB(DrmConnector index) {
+  int i;
+
+  /* Set atomic req */
+  drmModeAtomicReqPtr atomic_req = drmModeAtomicAlloc();
+  if (!atomic_req) {
+    printf("Atomic Alloc failed. Could not update fb_id\n");
+    return;
+  }
+
+  /* Add property */
+  for (i = 0; i < NUM_PLANES; i++)
+    drmModeAtomicAddProperty(atomic_req, plane_res[i].plane->plane_id, fb_prop_id,
+                             drm[index].GRSurfaceDrms[drm[index].current_buffer]->fb_id);
+
+  /* Commit changes */
+  int32_t ret;
+  ret = drmModeAtomicCommit(drm_fd, atomic_req, DRM_MODE_ATOMIC_ALLOW_MODESET, NULL);
+
+  drmModeAtomicFree(atomic_req);
+
+  if (ret) printf("Atomic commit failed ret=%d\n", ret);
 }
 
 GRSurface* MinuiBackendDrmQti::Init() {
@@ -406,68 +640,89 @@ GRSurface* MinuiBackendDrmQti::Init() {
 
   drmModeFreeResources(res);
 
-  // We will likely encounter errors in the backend functions (i.e. Flip) if EnableCrtc fails.
-  if (!DrmEnableCrtc(drm_fd, drm[DRM_MAIN].monitor_crtc, drm[DRM_MAIN].GRSurfaceDrms[1],
-                     &drm[DRM_MAIN].monitor_connector->connector_id)) {
-    return nullptr;
+  /* Get possible plane_ids */
+  drmModePlaneRes* plane_options = drmModeGetPlaneResources(drm_fd);
+  if (!plane_options) return NULL;
+
+  drmSetClientCap(drm_fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
+  drmSetClientCap(drm_fd, DRM_CLIENT_CAP_ATOMIC, 1);
+
+  /* Set crtc resources */
+  crtc_res.props =
+      drmModeObjectGetProperties(drm_fd, drm[DRM_MAIN].monitor_crtc->crtc_id, DRM_MODE_OBJECT_CRTC);
+  crtc_res.props_info = static_cast<drmModePropertyRes**>(
+      calloc(crtc_res.props->count_props, sizeof(crtc_res.props_info)));
+  if (!crtc_res.props || !crtc_res.props_info)
+    return NULL;
+  else
+    for (int j = 0; j < (int)crtc_res.props->count_props; ++j)
+      crtc_res.props_info[j] = drmModeGetProperty(drm_fd, crtc_res.props->props[j]);
+
+  /* Set connector resources */
+  conn_res.props = drmModeObjectGetProperties(drm_fd, drm[DRM_MAIN].monitor_connector->connector_id,
+                                              DRM_MODE_OBJECT_CONNECTOR);
+  conn_res.props_info = static_cast<drmModePropertyRes**>(
+      calloc(conn_res.props->count_props, sizeof(conn_res.props_info)));
+  if (!conn_res.props || !conn_res.props_info)
+    return NULL;
+  else
+    for (int j = 0; j < (int)conn_res.props->count_props; ++j)
+      conn_res.props_info[j] = drmModeGetProperty(drm_fd, conn_res.props->props[j]);
+
+  /* Set plane resources */
+  for (int i = 0; i < NUM_PLANES; ++i) {
+    plane_res[i].plane = drmModeGetPlane(drm_fd, plane_options->planes[i]);
+    if (!plane_res[i].plane) return NULL;
   }
+
+  for (int i = 0; i < NUM_PLANES; ++i) {
+    struct Plane* obj = &plane_res[i];
+    unsigned int j;
+    obj->props = drmModeObjectGetProperties(drm_fd, obj->plane->plane_id, DRM_MODE_OBJECT_PLANE);
+    if (!obj->props) continue;
+    obj->props_info = static_cast<drmModePropertyRes**>(
+        calloc(obj->props->count_props, sizeof(*obj->props_info)));
+    if (!obj->props_info) continue;
+    for (j = 0; j < obj->props->count_props; ++j)
+      obj->props_info[j] = drmModeGetProperty(drm_fd, obj->props->props[j]);
+  }
+
+  drmModeFreePlaneResources(plane_options);
+  plane_options = NULL;
+
+  /* Setup pipe and blob_id */
+  if (drmModeCreatePropertyBlob(drm_fd, &drm[DRM_MAIN].monitor_crtc->mode, sizeof(drmModeModeInfo),
+                                &crtc_res.mode_blob_id)) {
+    printf("failed to create mode blob\n");
+    return NULL;
+  }
+
+  /* Save fb_prop_id*/
+  uint32_t prop_id;
+  prop_id = find_plane_prop_id(plane_res[0].plane->plane_id, "FB_ID", plane_res);
+  fb_prop_id = prop_id;
+
+  Blank(false);
 
   return drm[DRM_MAIN].GRSurfaceDrms[0].get();
 }
 
-static void page_flip_complete(__unused int fd, __unused unsigned int sequence,
-                               __unused unsigned int tv_sec, __unused unsigned int tv_usec,
-                               void* user_data) {
-  *static_cast<bool*>(user_data) = false;
-}
-
 GRSurface* MinuiBackendDrmQti::Flip() {
-  GRSurface* surface = NULL;
-  DrmInterface* current_drm = &drm[active_display];
-  bool ongoing_flip = true;
+  UpdatePlaneFB(active_display);
 
-  if (!current_drm->monitor_connector) {
-    fprintf(stderr, "Unsupported. active_display = %d\n", active_display);
-    return nullptr;
-  }
-
-  if (drmModePageFlip(drm_fd, current_drm->monitor_crtc->crtc_id,
-                      current_drm->GRSurfaceDrms[current_drm->current_buffer]->fb_id,
-                      DRM_MODE_PAGE_FLIP_EVENT, &ongoing_flip) != 0) {
-    fprintf(stderr, "Failed to drmModePageFlip, active_display=%d", active_display);
-    return nullptr;
-  }
-
-  while (ongoing_flip) {
-    struct pollfd fds = { .fd = drm_fd, .events = POLLIN };
-
-    if (poll(&fds, 1, -1) == -1 || !(fds.revents & POLLIN)) {
-      perror("Failed to poll() on drm fd");
-      break;
-    }
-
-    drmEventContext evctx = { .version = DRM_EVENT_CONTEXT_VERSION,
-                              .page_flip_handler = page_flip_complete };
-
-    if (drmHandleEvent(drm_fd, &evctx) != 0) {
-      perror("Failed to drmHandleEvent");
-      break;
-    }
-  }
-
-  current_drm->current_buffer = 1 - current_drm->current_buffer;
-  surface = current_drm->GRSurfaceDrms[current_drm->current_buffer].get();
-  return surface;
+  drm[active_display].current_buffer = 1 - drm[active_display].current_buffer;
+  return drm[active_display].GRSurfaceDrms[drm[active_display].current_buffer].get();
 }
 
 MinuiBackendDrmQti::~MinuiBackendDrmQti() {
   for (int i = 0; i < DRM_MAX; i++) {
     if (drm[i].monitor_connector) {
-      DrmDisableCrtc(drm_fd, drm[i].monitor_crtc);
       drmModeFreeCrtc(drm[i].monitor_crtc);
       drmModeFreeConnector(drm[i].monitor_connector);
     }
   }
+  Blank(true);
+  drmModeDestroyPropertyBlob(drm_fd, crtc_res.mode_blob_id);
   close(drm_fd);
   drm_fd = -1;
 }

--- a/minui/graphics_drm_qti.cpp
+++ b/minui/graphics_drm_qti.cpp
@@ -89,28 +89,41 @@
  * @SDE_RM_TOPOLOGY_NONE:                 No topology in use currently
  * @SDE_RM_TOPOLOGY_SINGLEPIPE:           1 LM, 1 PP, 1 INTF/WB
  * @SDE_RM_TOPOLOGY_SINGLEPIPE_DSC:       1 LM, 1 DSC, 1 PP, 1 INTF/WB
+ * @SDE_RM_TOPOLOGY_SINGLEPIPE_VDC:       1 LM, 1 VDC, 1 PP, 1 INTF/WB
  * @SDE_RM_TOPOLOGY_DUALPIPE:             2 LM, 2 PP, 2 INTF/WB
  * @SDE_RM_TOPOLOGY_DUALPIPE_DSC:         2 LM, 2 DSC, 2 PP, 2 INTF/WB
  * @SDE_RM_TOPOLOGY_DUALPIPE_3DMERGE:     2 LM, 2 PP, 3DMux, 1 INTF/WB
  * @SDE_RM_TOPOLOGY_DUALPIPE_3DMERGE_DSC: 2 LM, 2 PP, 3DMux, 1 DSC, 1 INTF/WB
+ * @SDE_RM_TOPOLOGY_DUALPIPE_3DMERGE_VDC: 2 LM, 2 PP, 3DMux, 1 VDC, 1 INTF/WB
  * @SDE_RM_TOPOLOGY_DUALPIPE_DSCMERGE:    2 LM, 2 PP, 2 DSC Merge, 1 INTF/WB
  * @SDE_RM_TOPOLOGY_PPSPLIT:              1 LM, 2 PPs, 2 INTF/WB
+ * @SDE_RM_TOPOLOGY_QUADPIPE_3DMERGE      4 LM, 4 PP, 3DMux, 2 INTF
+ * @SDE_RM_TOPOLOGY_QUADPIPE_3DMERGE_DSC  4 LM, 4 PP, 3DMux, 3 DSC, 2 INTF
+ * @SDE_RM_TOPOLOGY_QUADPIPE_DSCMERE      4 LM, 4 PP, 4 DSC Merge, 2 INTF
+ * @SDE_RM_TOPOLOGY_QUADPIPE_DSC4HSMERGE  4 LM, 4 PP, 4 DSC Merge, 1 INTF
  */
 
 static uint32_t get_lm_number(const std::string& topology) {
   if (topology == "sde_singlepipe") return 1;
   if (topology == "sde_singlepipe_dsc") return 1;
+  if (topology == "sde_singlepipe_vdc") return 1;
   if (topology == "sde_dualpipe") return 2;
   if (topology == "sde_dualpipe_dsc") return 2;
+  if (topology == "sde_dualpipe_vdc") return 2;
   if (topology == "sde_dualpipemerge") return 2;
   if (topology == "sde_dualpipemerge_dsc") return 2;
+  if (topology == "sde_dualpipemerge_vdc") return 2;
   if (topology == "sde_dualpipe_dscmerge") return 2;
   if (topology == "sde_ppsplit") return 1;
-  return 2;
+  if (topology == "sde_quadpipemerge") return 4;
+  if (topology == "sde_quadpipe_3dmerge_dsc") return 4;
+  if (topology == "sde_quadpipe_dscmerge") return 4;
+  if (topology == "sde_quadpipe_dsc4hsmerge") return 4;
+  return DEFAULT_NUM_LMS;
 }
 
 static uint32_t get_topology_lm_number(int fd, uint32_t blob_id) {
-  uint32_t num_lm = 2;
+  uint32_t num_lm = DEFAULT_NUM_LMS;
 
   drmModePropertyBlobRes* blob = drmModeGetPropertyBlob(fd, blob_id);
   if (!blob) {
@@ -125,6 +138,7 @@ static uint32_t get_topology_lm_number(int fd, uint32_t blob_id) {
   while (std::getline(stream, line)) {
     if (line.find(topology) != std::string::npos) {
       num_lm = get_lm_number(std::string(line, topology.length()));
+      break;
     }
   }
 
@@ -180,14 +194,8 @@ int MinuiBackendDrmQti::AtomicPopulatePlane(int plane, drmModeAtomicReqPtr atomi
   crtc_y = 0;
   crtc_w = width / number_of_lms;
   crtc_h = height;
-
-  if (plane == Left) {
-    src_x = 0;
-    crtc_x = 0;
-  } else {
-    src_x = width / number_of_lms;
-    crtc_x = width / number_of_lms;
-  }
+  src_x = (width / number_of_lms) * plane;
+  crtc_x = (width / number_of_lms) * plane;
 
   if (atomic_add_prop_to_plane(plane_res, atomic_req, plane_res[plane].plane->plane_id, "FB_ID",
                                drm[index].GRSurfaceDrms[drm[index].current_buffer]->fb_id))
@@ -621,7 +629,7 @@ GRSurface* MinuiBackendDrmQti::Init() {
   drmModeRes* res = nullptr;
   drm_fd = -1;
 
-  number_of_lms = 2;
+  number_of_lms = DEFAULT_NUM_LMS;
   /* Consider DRM devices in order. */
   for (int i = 0; i < DRM_MAX_MINOR; i++) {
     auto dev_name = android::base::StringPrintf(DRM_DEV_NAME, DRM_DIR_NAME, i);
@@ -725,6 +733,9 @@ GRSurface* MinuiBackendDrmQti::Init() {
     for (int j = 0; j < (int)conn_res.props->count_props; ++j) {
       conn_res.props_info[j] = drmModeGetProperty(drm_fd, conn_res.props->props[j]);
 
+      /* Get preferred mode information and extract the
+       * number of layer mixers needed from the topology name.
+       */
       if (!strcmp(conn_res.props_info[j]->name, "mode_properties")) {
         number_of_lms = get_topology_lm_number(drm_fd, conn_res.props->prop_values[j]);
         printf("number of lms in topology %d\n", number_of_lms);

--- a/minui/graphics_drm_qti.cpp
+++ b/minui/graphics_drm_qti.cpp
@@ -642,7 +642,8 @@ GRSurface* MinuiBackendDrmQti::Init() {
 
   /* Get possible plane_ids */
   drmModePlaneRes* plane_options = drmModeGetPlaneResources(drm_fd);
-  if (!plane_options) return NULL;
+  if (!plane_options || !plane_options->planes || (plane_options->count_planes < NUM_PLANES))
+    return NULL;
 
   drmSetClientCap(drm_fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
   drmSetClientCap(drm_fd, DRM_CLIENT_CAP_ATOMIC, 1);
@@ -650,9 +651,11 @@ GRSurface* MinuiBackendDrmQti::Init() {
   /* Set crtc resources */
   crtc_res.props =
       drmModeObjectGetProperties(drm_fd, drm[DRM_MAIN].monitor_crtc->crtc_id, DRM_MODE_OBJECT_CRTC);
+  if (!crtc_res.props) return NULL;
+
   crtc_res.props_info = static_cast<drmModePropertyRes**>(
       calloc(crtc_res.props->count_props, sizeof(crtc_res.props_info)));
-  if (!crtc_res.props || !crtc_res.props_info)
+  if (!crtc_res.props_info)
     return NULL;
   else
     for (int j = 0; j < (int)crtc_res.props->count_props; ++j)
@@ -661,9 +664,11 @@ GRSurface* MinuiBackendDrmQti::Init() {
   /* Set connector resources */
   conn_res.props = drmModeObjectGetProperties(drm_fd, drm[DRM_MAIN].monitor_connector->connector_id,
                                               DRM_MODE_OBJECT_CONNECTOR);
+  if (!conn_res.props) return NULL;
+
   conn_res.props_info = static_cast<drmModePropertyRes**>(
       calloc(conn_res.props->count_props, sizeof(conn_res.props_info)));
-  if (!conn_res.props || !conn_res.props_info)
+  if (!conn_res.props_info)
     return NULL;
   else
     for (int j = 0; j < (int)conn_res.props->count_props; ++j)

--- a/minui/graphics_drm_qti.cpp
+++ b/minui/graphics_drm_qti.cpp
@@ -691,13 +691,13 @@ GRSurface* MinuiBackendDrmQti::Init() {
 
   drmModeFreeResources(res);
 
+  drmSetClientCap(drm_fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
+  drmSetClientCap(drm_fd, DRM_CLIENT_CAP_ATOMIC, 1);
+
   /* Get possible plane_ids */
   drmModePlaneRes* plane_options = drmModeGetPlaneResources(drm_fd);
   if (!plane_options || !plane_options->planes || (plane_options->count_planes < number_of_lms))
     return NULL;
-
-  drmSetClientCap(drm_fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
-  drmSetClientCap(drm_fd, DRM_CLIENT_CAP_ATOMIC, 1);
 
   /* Set crtc resources */
   crtc_res.props =

--- a/minui/graphics_drm_qti.cpp
+++ b/minui/graphics_drm_qti.cpp
@@ -1,0 +1,473 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "graphics_drm_qti.h"
+
+#include <fcntl.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <memory>
+
+#include <android-base/macros.h>
+#include <android-base/stringprintf.h>
+#include <android-base/unique_fd.h>
+#include <drm_fourcc.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+#include "minui/minui.h"
+
+GRSurfaceDrmQti::~GRSurfaceDrmQti() {
+  if (mmapped_buffer_) {
+    munmap(mmapped_buffer_, row_bytes * height);
+  }
+
+  if (fb_id) {
+    if (drmModeRmFB(drm_fd_, fb_id) != 0) {
+      perror("Failed to drmModeRmFB");
+      // Falling through to free other resources.
+    }
+  }
+
+  if (handle) {
+    drm_gem_close gem_close = {};
+    gem_close.handle = handle;
+
+    if (drmIoctl(drm_fd_, DRM_IOCTL_GEM_CLOSE, &gem_close) != 0) {
+      perror("Failed to DRM_IOCTL_GEM_CLOSE");
+    }
+  }
+}
+
+static int drm_format_to_bpp(uint32_t format) {
+  switch (format) {
+    case DRM_FORMAT_ABGR8888:
+    case DRM_FORMAT_BGRA8888:
+    case DRM_FORMAT_RGBX8888:
+    case DRM_FORMAT_RGBA8888:
+    case DRM_FORMAT_ARGB8888:
+    case DRM_FORMAT_BGRX8888:
+    case DRM_FORMAT_XBGR8888:
+    case DRM_FORMAT_XRGB8888:
+      return 32;
+    case DRM_FORMAT_RGB565:
+      return 16;
+    default:
+      printf("Unknown format %d\n", format);
+      return 32;
+  }
+}
+
+std::unique_ptr<GRSurfaceDrmQti> GRSurfaceDrmQti::Create(int drm_fd, int width, int height) {
+  uint32_t format;
+  PixelFormat pixel_format = gr_pixel_format();
+  // PixelFormat comes in byte order, whereas DRM_FORMAT_* uses little-endian
+  // (external/libdrm/include/drm/drm_fourcc.h). Note that although drm_fourcc.h also defines a
+  // macro of DRM_FORMAT_BIG_ENDIAN, it doesn't seem to be actually supported (see the discussion
+  // in https://lists.freedesktop.org/archives/amd-gfx/2017-May/008560.html).
+  if (pixel_format == PixelFormat::ABGR) {
+    format = DRM_FORMAT_RGBA8888;
+  } else if (pixel_format == PixelFormat::BGRA) {
+    format = DRM_FORMAT_ARGB8888;
+  } else if (pixel_format == PixelFormat::RGBX) {
+    format = DRM_FORMAT_XBGR8888;
+  } else if (pixel_format == PixelFormat::ARGB) {
+    format = DRM_FORMAT_BGRA8888;
+  } else if (pixel_format == PixelFormat::BGRX) {
+    format = DRM_FORMAT_XRGB8888;
+  } else {
+    format = DRM_FORMAT_RGB565;
+  }
+
+  drm_mode_create_dumb create_dumb = {};
+  create_dumb.height = height;
+  create_dumb.width = width;
+  create_dumb.bpp = drm_format_to_bpp(format);
+  create_dumb.flags = 0;
+
+  if (drmIoctl(drm_fd, DRM_IOCTL_MODE_CREATE_DUMB, &create_dumb) != 0) {
+    perror("Failed to DRM_IOCTL_MODE_CREATE_DUMB");
+    return nullptr;
+  }
+  printf("Allocating buffer with resolution %d x %d pitch: %d bpp: %d, size: %llu\n", width, height,
+         create_dumb.pitch, create_dumb.bpp, create_dumb.size);
+
+  // Cannot use std::make_unique to access non-public ctor.
+  auto surface = std::unique_ptr<GRSurfaceDrmQti>(new GRSurfaceDrmQti(
+      width, height, create_dumb.pitch, create_dumb.bpp / 8, drm_fd, create_dumb.handle));
+
+  uint32_t handles[4], pitches[4], offsets[4];
+
+  handles[0] = surface->handle;
+  pitches[0] = create_dumb.pitch;
+  offsets[0] = 0;
+  if (drmModeAddFB2(drm_fd, width, height, format, handles, pitches, offsets, &surface->fb_id, 0) !=
+      0) {
+    perror("Failed to drmModeAddFB2");
+    return nullptr;
+  }
+
+  drm_mode_map_dumb map_dumb = {};
+  map_dumb.handle = create_dumb.handle;
+  if (drmIoctl(drm_fd, DRM_IOCTL_MODE_MAP_DUMB, &map_dumb) != 0) {
+    perror("Failed to DRM_IOCTL_MODE_MAP_DUMB");
+    return nullptr;
+  }
+
+  auto mmapped =
+      mmap(nullptr, create_dumb.size, PROT_READ | PROT_WRITE, MAP_SHARED, drm_fd, map_dumb.offset);
+  if (mmapped == MAP_FAILED) {
+    perror("Failed to mmap()");
+    return nullptr;
+  }
+  surface->mmapped_buffer_ = static_cast<uint8_t*>(mmapped);
+  printf("Framebuffer of size %llu allocated @ %p\n", create_dumb.size, surface->mmapped_buffer_);
+  return surface;
+}
+
+void MinuiBackendDrmQti::DrmDisableCrtc(int drm_fd, drmModeCrtc* crtc) {
+  if (crtc) {
+    drmModeSetCrtc(drm_fd, crtc->crtc_id,
+                   0,         // fb_id
+                   0, 0,      // x,y
+                   nullptr,   // connectors
+                   0,         // connector_count
+                   nullptr);  // mode
+  }
+}
+
+bool MinuiBackendDrmQti::DrmEnableCrtc(int drm_fd, drmModeCrtc* crtc,
+                                       const std::unique_ptr<GRSurfaceDrmQti>& surface,
+                                       uint32_t* connector_id) {
+  if (drmModeSetCrtc(drm_fd, crtc->crtc_id, surface->fb_id, 0, 0,  // x,y
+                     connector_id, 1,                              // connector_count
+                     &crtc->mode) != 0) {
+    fprintf(stderr, "Failed to drmModeSetCrtc(%d)\n", *connector_id);
+    return false;
+  }
+
+  return true;
+}
+
+void MinuiBackendDrmQti::Blank(bool blank) {
+  Blank(blank, DRM_MAIN);
+}
+
+void MinuiBackendDrmQti::Blank(bool blank, DrmConnector index) {
+  const auto* drmInterface = &drm[DRM_MAIN];
+
+  switch (index) {
+    case DRM_MAIN:
+      drmInterface = &drm[DRM_MAIN];
+      break;
+    case DRM_SEC:
+      drmInterface = &drm[DRM_SEC];
+      break;
+    default:
+      fprintf(stderr, "Invalid index: %d\n", index);
+      return;
+  }
+
+  if (!drmInterface->monitor_connector) {
+    fprintf(stderr, "Unsupported. index = %d\n", index);
+    return;
+  }
+
+  if (blank) {
+    DrmDisableCrtc(drm_fd, drmInterface->monitor_crtc);
+  } else {
+    DrmEnableCrtc(drm_fd, drmInterface->monitor_crtc,
+                  drmInterface->GRSurfaceDrms[drmInterface->current_buffer],
+                  &drmInterface->monitor_connector->connector_id);
+
+    active_display = index;
+  }
+}
+
+bool MinuiBackendDrmQti::HasMultipleConnectors() {
+  return (drm[DRM_SEC].GRSurfaceDrms[0] && drm[DRM_SEC].GRSurfaceDrms[1]);
+}
+
+static drmModeCrtc* find_crtc_for_connector(int fd, drmModeRes* resources,
+                                            drmModeConnector* connector) {
+  // Find the encoder. If we already have one, just use it.
+  drmModeEncoder* encoder;
+  if (connector->encoder_id) {
+    encoder = drmModeGetEncoder(fd, connector->encoder_id);
+  } else {
+    encoder = nullptr;
+  }
+
+  int32_t crtc;
+  if (encoder && encoder->crtc_id) {
+    crtc = encoder->crtc_id;
+    drmModeFreeEncoder(encoder);
+    return drmModeGetCrtc(fd, crtc);
+  }
+
+  // Didn't find anything, try to find a crtc and encoder combo.
+  crtc = -1;
+  for (int i = 0; i < connector->count_encoders; i++) {
+    encoder = drmModeGetEncoder(fd, connector->encoders[i]);
+
+    if (encoder) {
+      for (int j = 0; j < resources->count_crtcs; j++) {
+        if (!(encoder->possible_crtcs & (1 << j))) continue;
+        crtc = resources->crtcs[j];
+        break;
+      }
+      if (crtc >= 0) {
+        drmModeFreeEncoder(encoder);
+        return drmModeGetCrtc(fd, crtc);
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+std::vector<drmModeConnector*> find_used_connector_by_type(int fd, drmModeRes* resources,
+                                                           unsigned type) {
+  std::vector<drmModeConnector*> drmConnectors;
+  for (int i = 0; i < resources->count_connectors; i++) {
+    drmModeConnector* connector = drmModeGetConnector(fd, resources->connectors[i]);
+    if (connector) {
+      if ((connector->connector_type == type) && (connector->connection == DRM_MODE_CONNECTED) &&
+          (connector->count_modes > 0)) {
+        drmConnectors.push_back(connector);
+      } else {
+        drmModeFreeConnector(connector);
+      }
+    }
+  }
+  return drmConnectors;
+}
+
+static drmModeConnector* find_first_connected_connector(int fd, drmModeRes* resources) {
+  for (int i = 0; i < resources->count_connectors; i++) {
+    drmModeConnector* connector;
+
+    connector = drmModeGetConnector(fd, resources->connectors[i]);
+    if (connector) {
+      if ((connector->count_modes > 0) && (connector->connection == DRM_MODE_CONNECTED))
+        return connector;
+
+      drmModeFreeConnector(connector);
+    }
+  }
+  return nullptr;
+}
+
+bool MinuiBackendDrmQti::FindAndSetMonitor(int fd, drmModeRes* resources) {
+  /* Look for LVDS/eDP/DSI connectors. Those are the main screens. */
+  static constexpr unsigned kConnectorPriority[] = {
+    DRM_MODE_CONNECTOR_LVDS,
+    DRM_MODE_CONNECTOR_eDP,
+    DRM_MODE_CONNECTOR_DSI,
+  };
+
+  std::vector<drmModeConnector*> drmConnectors;
+  for (int i = 0; i < arraysize(kConnectorPriority) && drmConnectors.size() < DRM_MAX; i++) {
+    auto connectors = find_used_connector_by_type(fd, resources, kConnectorPriority[i]);
+    for (auto connector : connectors) {
+      drmConnectors.push_back(connector);
+      if (drmConnectors.size() >= DRM_MAX) break;
+    }
+  }
+
+  /* If we didn't find a connector, grab the first one that is connected. */
+  if (drmConnectors.empty()) {
+    drmModeConnector* connector = find_first_connected_connector(fd, resources);
+    if (connector) {
+      drmConnectors.push_back(connector);
+    }
+  }
+
+  for (int drm_index = 0; drm_index < drmConnectors.size(); drm_index++) {
+    drm[drm_index].monitor_connector = drmConnectors[drm_index];
+
+    drm[drm_index].selected_mode = 0;
+    for (int modes = 0; modes < drmConnectors[drm_index]->count_modes; modes++) {
+      printf("Display Mode %d resolution: %d x %d @ %d FPS\n", modes,
+             drmConnectors[drm_index]->modes[modes].hdisplay,
+             drmConnectors[drm_index]->modes[modes].vdisplay,
+             drmConnectors[drm_index]->modes[modes].vrefresh);
+      if (drmConnectors[drm_index]->modes[modes].type & DRM_MODE_TYPE_PREFERRED) {
+        printf("Choosing display mode #%d\n", modes);
+        drm[drm_index].selected_mode = modes;
+        break;
+      }
+    }
+  }
+
+  return drmConnectors.size() > 0;
+}
+
+void MinuiBackendDrmQti::DisableNonMainCrtcs(int fd, drmModeRes* resources,
+                                             drmModeCrtc* main_crtc) {
+  for (int i = 0; i < resources->count_connectors; i++) {
+    drmModeConnector* connector = drmModeGetConnector(fd, resources->connectors[i]);
+    drmModeCrtc* crtc = find_crtc_for_connector(fd, resources, connector);
+    if (crtc->crtc_id != main_crtc->crtc_id) {
+      DrmDisableCrtc(fd, crtc);
+    }
+    drmModeFreeCrtc(crtc);
+  }
+}
+
+GRSurface* MinuiBackendDrmQti::Init() {
+  drmModeRes* res = nullptr;
+  drm_fd = -1;
+
+  /* Consider DRM devices in order. */
+  for (int i = 0; i < DRM_MAX_MINOR; i++) {
+    auto dev_name = android::base::StringPrintf(DRM_DEV_NAME, DRM_DIR_NAME, i);
+    android::base::unique_fd fd(open(dev_name.c_str(), O_RDWR | O_CLOEXEC));
+    if (fd == -1) continue;
+
+    /* We need dumb buffers. */
+    if (uint64_t cap = 0; drmGetCap(fd.get(), DRM_CAP_DUMB_BUFFER, &cap) != 0 || cap == 0) {
+      continue;
+    }
+
+    res = drmModeGetResources(fd.get());
+    if (!res) {
+      continue;
+    }
+
+    /* Use this device if it has at least one connected monitor. */
+    if (res->count_crtcs > 0 && res->count_connectors > 0) {
+      if (find_first_connected_connector(fd.get(), res)) {
+        drm_fd = fd.release();
+        break;
+      }
+    }
+
+    drmModeFreeResources(res);
+    res = nullptr;
+  }
+
+  if (drm_fd == -1 || res == nullptr) {
+    perror("Failed to find/open a drm device");
+    return nullptr;
+  }
+
+  if (!FindAndSetMonitor(drm_fd, res)) {
+    fprintf(stderr, "Failed to find main monitor_connector\n");
+    drmModeFreeResources(res);
+    return nullptr;
+  }
+
+  for (int i = 0; i < DRM_MAX; i++) {
+    if (drm[i].monitor_connector) {
+      drm[i].monitor_crtc = find_crtc_for_connector(drm_fd, res, drm[i].monitor_connector);
+      if (!drm[i].monitor_crtc) {
+        fprintf(stderr, "Failed to find monitor_crtc, drm index=%d\n", i);
+        drmModeFreeResources(res);
+        return nullptr;
+      }
+
+      drm[i].monitor_crtc->mode = drm[i].monitor_connector->modes[drm[i].selected_mode];
+
+      int width = drm[i].monitor_crtc->mode.hdisplay;
+      int height = drm[i].monitor_crtc->mode.vdisplay;
+
+      drm[i].GRSurfaceDrms[0] = GRSurfaceDrmQti::Create(drm_fd, width, height);
+      drm[i].GRSurfaceDrms[1] = GRSurfaceDrmQti::Create(drm_fd, width, height);
+      if (!drm[i].GRSurfaceDrms[0] || !drm[i].GRSurfaceDrms[1]) {
+        fprintf(stderr, "Failed to create GRSurfaceDrmQti, drm index=%d\n", i);
+        drmModeFreeResources(res);
+        return nullptr;
+      }
+
+      drm[i].current_buffer = 0;
+    }
+  }
+
+  DisableNonMainCrtcs(drm_fd, res, drm[DRM_MAIN].monitor_crtc);
+
+  drmModeFreeResources(res);
+
+  // We will likely encounter errors in the backend functions (i.e. Flip) if EnableCrtc fails.
+  if (!DrmEnableCrtc(drm_fd, drm[DRM_MAIN].monitor_crtc, drm[DRM_MAIN].GRSurfaceDrms[1],
+                     &drm[DRM_MAIN].monitor_connector->connector_id)) {
+    return nullptr;
+  }
+
+  return drm[DRM_MAIN].GRSurfaceDrms[0].get();
+}
+
+static void page_flip_complete(__unused int fd, __unused unsigned int sequence,
+                               __unused unsigned int tv_sec, __unused unsigned int tv_usec,
+                               void* user_data) {
+  *static_cast<bool*>(user_data) = false;
+}
+
+GRSurface* MinuiBackendDrmQti::Flip() {
+  GRSurface* surface = NULL;
+  DrmInterface* current_drm = &drm[active_display];
+  bool ongoing_flip = true;
+
+  if (!current_drm->monitor_connector) {
+    fprintf(stderr, "Unsupported. active_display = %d\n", active_display);
+    return nullptr;
+  }
+
+  if (drmModePageFlip(drm_fd, current_drm->monitor_crtc->crtc_id,
+                      current_drm->GRSurfaceDrms[current_drm->current_buffer]->fb_id,
+                      DRM_MODE_PAGE_FLIP_EVENT, &ongoing_flip) != 0) {
+    fprintf(stderr, "Failed to drmModePageFlip, active_display=%d", active_display);
+    return nullptr;
+  }
+
+  while (ongoing_flip) {
+    struct pollfd fds = { .fd = drm_fd, .events = POLLIN };
+
+    if (poll(&fds, 1, -1) == -1 || !(fds.revents & POLLIN)) {
+      perror("Failed to poll() on drm fd");
+      break;
+    }
+
+    drmEventContext evctx = { .version = DRM_EVENT_CONTEXT_VERSION,
+                              .page_flip_handler = page_flip_complete };
+
+    if (drmHandleEvent(drm_fd, &evctx) != 0) {
+      perror("Failed to drmHandleEvent");
+      break;
+    }
+  }
+
+  current_drm->current_buffer = 1 - current_drm->current_buffer;
+  surface = current_drm->GRSurfaceDrms[current_drm->current_buffer].get();
+  return surface;
+}
+
+MinuiBackendDrmQti::~MinuiBackendDrmQti() {
+  for (int i = 0; i < DRM_MAX; i++) {
+    if (drm[i].monitor_connector) {
+      DrmDisableCrtc(drm_fd, drm[i].monitor_crtc);
+      drmModeFreeCrtc(drm[i].monitor_crtc);
+      drmModeFreeConnector(drm[i].monitor_connector);
+    }
+  }
+  close(drm_fd);
+  drm_fd = -1;
+}

--- a/minui/graphics_drm_qti.cpp
+++ b/minui/graphics_drm_qti.cpp
@@ -605,8 +605,8 @@ static drmModeCrtc* find_crtc_for_connector(int fd, drmModeRes* resources,
   return nullptr;
 }
 
-std::vector<drmModeConnector*> find_used_connector_by_type(int fd, drmModeRes* resources,
-                                                           unsigned type) {
+static std::vector<drmModeConnector*> find_used_connector_by_type(int fd, drmModeRes* resources,
+                                                                  unsigned type) {
   std::vector<drmModeConnector*> drmConnectors;
   for (int i = 0; i < resources->count_connectors; i++) {
     drmModeConnector* connector = drmModeGetConnector(fd, resources->connectors[i]);

--- a/minui/graphics_drm_qti.h
+++ b/minui/graphics_drm_qti.h
@@ -26,6 +26,26 @@
 #include "graphics.h"
 #include "minui/minui.h"
 
+#define NUM_MAIN 1
+#define NUM_PLANES 2
+
+struct Crtc {
+  drmModeObjectProperties* props;
+  drmModePropertyRes** props_info;
+  uint32_t mode_blob_id;
+};
+
+struct Connector {
+  drmModeObjectProperties* props;
+  drmModePropertyRes** props_info;
+};
+
+struct Plane {
+  drmModePlane* plane;
+  drmModeObjectProperties* props;
+  drmModePropertyRes** props_info;
+};
+
 class GRSurfaceDrmQti : public GRSurface {
  public:
   ~GRSurfaceDrmQti() override;
@@ -63,10 +83,15 @@ class MinuiBackendDrmQti : public MinuiBackend {
   bool HasMultipleConnectors() override;
 
  private:
-  void DrmDisableCrtc(int drm_fd, drmModeCrtc* crtc);
+  int DrmDisableCrtc(drmModeAtomicReqPtr atomic_req, DrmConnector index);
+  int DrmEnableCrtc(drmModeAtomicReqPtr atomic_req, DrmConnector index);
   bool DrmEnableCrtc(int drm_fd, drmModeCrtc* crtc, const std::unique_ptr<GRSurfaceDrmQti>& surface,
                      uint32_t* conntcors);
   void DisableNonMainCrtcs(int fd, drmModeRes* resources, drmModeCrtc* main_crtc);
+  int SetupPipeline(drmModeAtomicReqPtr atomic_req, DrmConnector index);
+  int TeardownPipeline(drmModeAtomicReqPtr atomic_req, DrmConnector index);
+  void UpdatePlaneFB(DrmConnector index);
+  int AtomicPopulatePlane(int plane, drmModeAtomicReqPtr atomic_req, DrmConnector index);
   bool FindAndSetMonitor(int fd, drmModeRes* resources);
 
   struct DrmInterface {
@@ -79,4 +104,9 @@ class MinuiBackendDrmQti : public MinuiBackend {
 
   int drm_fd{ -1 };
   DrmConnector active_display = DRM_MAIN;
+  bool current_blank_state = true;
+  int fb_prop_id;
+  struct Crtc crtc_res;
+  struct Connector conn_res;
+  struct Plane plane_res[NUM_PLANES];
 };

--- a/minui/graphics_drm_qti.h
+++ b/minui/graphics_drm_qti.h
@@ -27,7 +27,8 @@
 #include "minui/minui.h"
 
 #define NUM_MAIN 1
-#define NUM_PLANES 2
+#define NUM_PLANES 4
+#define DEFAULT_NUM_LMS 2
 
 struct Crtc {
   drmModeObjectProperties* props;

--- a/minui/graphics_drm_qti.h
+++ b/minui/graphics_drm_qti.h
@@ -19,6 +19,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <array>
+#include <map>
 #include <memory>
 
 #include <xf86drmMode.h>
@@ -30,10 +32,97 @@
 #define NUM_PLANES 4
 #define DEFAULT_NUM_LMS 2
 
+#define SPR_INIT_PARAM_SIZE_1 4
+#define SPR_INIT_PARAM_SIZE_2 5
+#define SPR_INIT_PARAM_SIZE_3 16
+#define SPR_INIT_PARAM_SIZE_4 24
+#define SPR_INIT_PARAM_SIZE_5 32
+#define SPR_INIT_PARAM_SIZE_6 7
+
+enum class SPRPackType {
+  kPentile,
+  kRGBW,
+  kYYGW,
+  kYYGM,
+  kDelta3,
+  kMax = 0xFF,
+};
+
+enum class SPRFilterType {
+  kPixelDrop,
+  kBilinear,
+  kFourTap,
+  kAdaptive,
+  k2DAvg,
+  kMax = 0xFF,
+};
+
+enum class SPRAdaptiveModeType {
+  kYYGM,
+  kYYGW,
+  kMax = 0xFF,
+};
+
+static const std::map<SPRPackType, uint32_t> kDefaultColorPhaseIncrement = {
+  { { { SPRPackType::kPentile }, { 8 } },
+    { { SPRPackType::kYYGM }, { 6 } },
+    { { SPRPackType::kYYGW }, { 6 } },
+    { { SPRPackType::kDelta3 }, { 6 } },
+    { { SPRPackType::kRGBW }, { 8 } } }
+};
+static const std::map<SPRPackType, uint32_t> kDefaultColorPhaseRepeat = {
+  { { { SPRPackType::kPentile }, { 2 } },
+    { { SPRPackType::kYYGM }, { 2 } },
+    { { SPRPackType::kYYGW }, { 2 } },
+    { { SPRPackType::kDelta3 }, { 2 } },
+    { { SPRPackType::kRGBW }, { 2 } } }
+};
+static const std::map<SPRPackType, std::array<uint16_t, SPR_INIT_PARAM_SIZE_1>> kDecimationRatioMap{
+  {
+      { { SPRPackType::kPentile }, { 1, 0, 1, 0 } },
+      { { SPRPackType::kYYGM }, { 2, 2, 2, 0 } },
+      { { SPRPackType::kYYGW }, { 2, 2, 2, 0 } },
+      { { SPRPackType::kRGBW }, { 1, 1, 1, 1 } },
+  }
+};
+static const std::map<SPRFilterType, std::array<int16_t, SPR_INIT_PARAM_SIZE_3>>
+    kDefaultFilterCoeffsMap{
+      { { { SPRFilterType::kPixelDrop }, { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
+        { { SPRFilterType::kBilinear },
+          { 0, 512, 0, 0, -33, 443, 110, -8, -23, 279, 279, -23, -8, 110, 443, -33 } },
+        { { SPRFilterType::kFourTap },
+          { 128, 256, 128, 0, 86, 241, 164, 21, 52, 204, 204, 52, 21, 164, 241, 86 } },
+        { { SPRFilterType::kAdaptive },
+          { 0, 256, 256, 0, 0, 256, 256, 0, 0, 256, 256, 0, 0, 256, 256, 0 } } }
+    };
+static const std::map<SPRPackType, std::array<int16_t, SPR_INIT_PARAM_SIZE_4>>
+    kDefaultColorPhaseMap{
+      { { { SPRPackType::kPentile },
+          { -2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, -2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
+        { { SPRPackType::kYYGM },
+          { -3, 0, 0, 0, 0, 0, -1, 2, 1, 1, 0, 0, 1, -2, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0 } },
+        { { SPRPackType::kYYGW },
+          { -4, 2, 0, 0, 0, -1, 2, 2, 0, -1, -1, -1, 2, 2, -1, -1, -1, 2, 0, 0, 0, 0, 0, 0 } },
+        { { SPRPackType::kDelta3 },
+          { -3, 0, 0, 0, 0, 0, 0, -3, 0, 0, 0, 0, -3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
+        { { SPRPackType::kRGBW },
+          { -4, 0, 0, 0, 0, 0, -2, 2, 0, 0, 0, 0, 0, -4, 0, 0, 0, 0, 2, -2, 0, 0, 0, 0 } } }
+    };
+static const std::array<uint16_t, SPR_INIT_PARAM_SIZE_1> kDefaultRGBWGains = { 1024, 1024, 1024,
+                                                                               341 };
+static const std::array<uint16_t, SPR_INIT_PARAM_SIZE_1> kDefaultOPRGains = { 341, 341, 341, 0 };
+static const std::array<uint16_t, SPR_INIT_PARAM_SIZE_2> kDefaultAdaptiveStrengths = { 0, 4, 8, 12,
+                                                                                       16 };
+static const std::array<uint16_t, SPR_INIT_PARAM_SIZE_5> kDefaultOPROffsets = {
+  0,    132,  264,  396,  529,  661,  793,  925,  1057, 1189, 1321, 1453, 1586, 1718, 1850, 1982,
+  2114, 2246, 2378, 2510, 2643, 2775, 2907, 3039, 3171, 3303, 3435, 3567, 3700, 3832, 3964, 4095
+};
+
 struct Crtc {
   drmModeObjectProperties* props;
   drmModePropertyRes** props_info;
   uint32_t mode_blob_id;
+  uint32_t spr_blob_id;
 };
 
 struct Connector {
@@ -45,6 +134,52 @@ struct Plane {
   drmModePlane* plane;
   drmModeObjectProperties* props;
   drmModePropertyRes** props_info;
+};
+
+struct drm_msm_spr_init_cfg {
+  __u64 flags;
+  __u16 cfg0;
+  __u16 cfg1;
+  __u16 cfg2;
+  __u16 cfg3;
+  __u16 cfg4;
+  __u16 cfg5;
+  __u16 cfg6;
+  __u16 cfg7;
+  __u16 cfg8;
+  __u16 cfg9;
+  __u32 cfg10;
+  __u16 cfg11[SPR_INIT_PARAM_SIZE_1];
+  __u16 cfg12[SPR_INIT_PARAM_SIZE_1];
+  __u16 cfg13[SPR_INIT_PARAM_SIZE_1];
+  __u16 cfg14[SPR_INIT_PARAM_SIZE_2];
+  __u16 cfg15[SPR_INIT_PARAM_SIZE_5];
+  int cfg16[SPR_INIT_PARAM_SIZE_3];
+  int cfg17[SPR_INIT_PARAM_SIZE_4];
+};
+
+struct drm_msm_spr_init_cfg_v2 {
+  __u64 flags;
+  __u16 cfg0;
+  __u16 cfg1;
+  __u16 cfg2;
+  __u16 cfg3;
+  __u16 cfg4;
+  __u16 cfg5;
+  __u16 cfg6;
+  __u16 cfg7;
+  __u16 cfg8;
+  __u16 cfg9;
+  __u32 cfg10;
+  __u16 cfg11[SPR_INIT_PARAM_SIZE_1];
+  __u16 cfg12[SPR_INIT_PARAM_SIZE_1];
+  __u16 cfg13[SPR_INIT_PARAM_SIZE_1];
+  __u16 cfg14[SPR_INIT_PARAM_SIZE_2];
+  __u16 cfg15[SPR_INIT_PARAM_SIZE_5];
+  int cfg16[SPR_INIT_PARAM_SIZE_3];
+  int cfg17[SPR_INIT_PARAM_SIZE_4];
+  __u16 cfg18_en;
+  __u8 cfg18[SPR_INIT_PARAM_SIZE_6];
 };
 
 class GRSurfaceDrmQti : public GRSurface {
@@ -111,4 +246,6 @@ class MinuiBackendDrmQti : public MinuiBackend {
   struct Connector conn_res;
   struct Plane plane_res[NUM_PLANES];
   uint32_t number_of_lms;
+  uint32_t spr_enabled;
+  std::string spr_prop_name;
 };

--- a/minui/graphics_drm_qti.h
+++ b/minui/graphics_drm_qti.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <memory>
+
+#include <xf86drmMode.h>
+
+#include "graphics.h"
+#include "minui/minui.h"
+
+class GRSurfaceDrmQti : public GRSurface {
+ public:
+  ~GRSurfaceDrmQti() override;
+
+  // Creates a GRSurfaceDrmQti instance.
+  static std::unique_ptr<GRSurfaceDrmQti> Create(int drm_fd, int width, int height);
+
+  uint8_t* data() override {
+    return mmapped_buffer_;
+  }
+
+ private:
+  friend class MinuiBackendDrmQti;
+
+  GRSurfaceDrmQti(size_t width, size_t height, size_t row_bytes, size_t pixel_bytes, int drm_fd,
+                  uint32_t handle)
+      : GRSurface(width, height, row_bytes, pixel_bytes), drm_fd_(drm_fd), handle(handle) {}
+
+  const int drm_fd_;
+
+  uint32_t fb_id{ 0 };
+  uint32_t handle{ 0 };
+  uint8_t* mmapped_buffer_{ nullptr };
+};
+
+class MinuiBackendDrmQti : public MinuiBackend {
+ public:
+  MinuiBackendDrmQti() = default;
+  ~MinuiBackendDrmQti() override;
+
+  GRSurface* Init() override;
+  GRSurface* Flip() override;
+  void Blank(bool) override;
+  void Blank(bool blank, DrmConnector index) override;
+  bool HasMultipleConnectors() override;
+
+ private:
+  void DrmDisableCrtc(int drm_fd, drmModeCrtc* crtc);
+  bool DrmEnableCrtc(int drm_fd, drmModeCrtc* crtc, const std::unique_ptr<GRSurfaceDrmQti>& surface,
+                     uint32_t* conntcors);
+  void DisableNonMainCrtcs(int fd, drmModeRes* resources, drmModeCrtc* main_crtc);
+  bool FindAndSetMonitor(int fd, drmModeRes* resources);
+
+  struct DrmInterface {
+    std::unique_ptr<GRSurfaceDrmQti> GRSurfaceDrms[2];
+    int current_buffer{ 0 };
+    drmModeCrtc* monitor_crtc{ nullptr };
+    drmModeConnector* monitor_connector{ nullptr };
+    uint32_t selected_mode{ 0 };
+  } drm[DRM_MAX];
+
+  int drm_fd{ -1 };
+  DrmConnector active_display = DRM_MAIN;
+};

--- a/minui/graphics_drm_qti.h
+++ b/minui/graphics_drm_qti.h
@@ -109,4 +109,5 @@ class MinuiBackendDrmQti : public MinuiBackend {
   struct Crtc crtc_res;
   struct Connector conn_res;
   struct Plane plane_res[NUM_PLANES];
+  uint32_t number_of_lms;
 };


### PR DESCRIPTION
These are mostly just cherry-picks from https://github.com/LineageOS/android_bootable_recovery/commits/lineage-22.2 (Android 15) and allow at least OnePlus 6(T) and possibly other Qualcomm `android-4.9-p` etc based devices to use the unified recovery base at long last :)

Other devices tested on include: OnePlus 5 (QCOM k4.4), Pixel Watch 2 (QCOM k5.15), Volla Phone Plinius (MTK k6.1), Zinwa Q25 (MTK k5.10) and Volla Phone 22 (MTK k4.19)