### PR TITLE
[halium-14.0] system-image-upgrader: better detect system partition on newer devices

### DIFF
--- a/ubports/system-image-upgrader
+++ b/ubports/system-image-upgrader
@@ -562,7 +562,7 @@ USE_SYSTEM_PARTITION=1
 # However, do not use the block device name in the kernel command line, as that is not consistently
 # named in booting normal and recovery modes. Expect fstab to have a system mountpoint or use a fallback.
 if [ "$USE_SYSTEM_PARTITION" -eq 1 ];then
-    SYSTEM_PARTITION=$(grep "^[^#]" /etc/fstab | grep -e "\(/mnt\)*/system\(_root\)*" | cut -f 1 -d\ )
+    SYSTEM_PARTITION=$(grep "^[^#].*\(/mnt\)*/system\(_root\)* " /etc/fstab | cut -f 1 -d\ )
     #Fall back to emmc@android if there's no system in fstab
     if [ "$SYSTEM_PARTITION" == "" ]; then
         SYSTEM_PARTITION="emmc@android"


### PR DESCRIPTION
Namely on those with `system_ext` (FP4/Q25) or `system_dlkm` (Volla Phone Plinius) dynparts which this would incorrectly also pick up from recovery fstab previously and fail.

Closes #56 (and #30 since FP4 likely will also move to unified recovery which should boot/work everywhere by now)