### PR TITLE
[halium-14.0] Always initialize screensaver if write goes through

### DIFF
--- a/recovery_ui/ui.cpp
+++ b/recovery_ui/ui.cpp
@@ -198,6 +198,12 @@ bool RecoveryUI::InitScreensaver() {
   if (!android::base::WriteStringToFile(std::to_string(brightness_normal_value_),
                                         brightness_file_)) {
     PLOG(WARNING) << "Failed to set brightness";
+  }
+  // On some devices (e.g. SDM845 OnePlus 6) above "fails" with EINVAL but 50% brightness is set
+  unsigned int new_value;
+  if (!android::base::ReadFileToString(brightness_file_, &content) ||
+      !android::base::ParseUint(android::base::Trim(content), &new_value) ||
+      new_value != brightness_normal_value_) {
     return false;
   }
 


### PR DESCRIPTION
During recovery start (including via `adb shell setprop ctl.restart recovery`) currently `RecoveryUI::InitScreensaver()` may fail on devices like OnePlus 6 with SDM845 SoC leaving the AMOLED display always at 50% brightness while the write actually did work but returned `EINVAL`.

`/tmp/recovery.log` before:
```
[    0.017420] W:Failed to set brightness: Invalid argument
[    0.017430] I:Screensaver disabled
```
versus after:
```
[    0.018334] W:Failed to set brightness: Invalid argument
[    0.018346] I:Brightness: 511 (50%)
[  120.447252] I:Brightness: 255 (25%)
[  240.453788] I:Brightness: 0 (off)
```