### PR TITLE
Support updates on Android/Volla Boot Manager multi/dual-boot

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -216,6 +216,7 @@ cc_binary {
         "simgtest_ubports",
         "system-image-upgrader",
         "tune2fs.recovery",
+        "unpackbootimg_ubports",
     ],
 }
 

--- a/Android.bp
+++ b/Android.bp
@@ -196,6 +196,7 @@ cc_binary {
         "ueventd.rc.recovery",
 
         // ubports
+        "abm",
         "archive-master.tar.xz",
         "archive-master.tar.xz.asc",
         "busybox_recovery",

--- a/ubports/Android.mk
+++ b/ubports/Android.mk
@@ -18,6 +18,14 @@ LOCAL_PATH := $(call my-dir)
 # ===============================
 
 include $(CLEAR_VARS)
+LOCAL_MODULE := abm
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := EXECUTABLES
+LOCAL_MODULE_PATH := $(TARGET_RECOVERY_ROOT_OUT)/system/bin
+LOCAL_SRC_FILES := $(LOCAL_MODULE)
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
 LOCAL_MODULE := archive-master.tar.xz
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_CLASS := ETC

--- a/ubports/abm
+++ b/ubports/abm
@@ -1,0 +1,82 @@
+#!/system/bin/sh
+# shellcheck disable=SC3034,3060
+BOOTSET="" # e.g. "/dev/block/mmcblk0p1"
+UT_ROOTFS="" # e.g. "/dev/block/mmcblk0p2"
+UT_ROOTFS_REAL="" # e.g. "/dev/mmcblk0p2"
+UT_USERDATA="" # e.g. "/dev/block/mmcblk0p3"
+UT_USERDATA_REAL="" # e.g. "/dev/block/mmcblk0p3"
+UT_CONF="" # e.g. "/bootset/db/entries/rom0.conf"
+
+prepare_bootset() {
+    # TODO: support internal storage variant (algiz) with userdata-mapped blocks instead
+    # -> https://github.com/Android-Boot-Manager/droidboot_map_to_dm
+    BOOTSET="$(find /dev/block/ -name 'abm_settings' -printf '%l')"
+}
+
+is_multiboot() {
+    prepare_bootset
+    # shellcheck disable=SC2143 # always non-zero exit code on pre-GKI devices without bootconfig
+    [ "$(grep -e 'has_dualboot' -e 'hasdualboot' /proc/bootconfig /proc/cmdline 2>/dev/null)" ] && [ -b "$BOOTSET" ]
+}
+
+setup_bootset() {
+    prepare_bootset
+    mkdir -p /bootset
+    if ! mountpoint -q /bootset; then
+        if ! mount "$BOOTSET" /bootset; then
+            echo "abm: couldn't mount ABM bootset ($BOOTSET)"
+            exit 1
+        fi
+        bootset_just_mounted=1
+    fi
+    UT_CONF=$(i=$(</bootset/db/last_index); stat -c '%i %n' /bootset/db/entries/* | sort -V | awk "NR == $((i+1)) {print \$2}")
+    if ! grep -q '^xtype UT$' "$UT_CONF"; then
+        echo "abm: $UT_CONF doesn't appear to be an Ubuntu Touch entry (xtype)"
+        exit 1
+    fi
+    for x in $(</proc/cmdline); do
+        case ${x} in
+            systempart=*) UT_ROOTFS_REAL=${x#*=}; UT_ROOTFS=${UT_ROOTFS_REAL/\/dev/\/dev\/block} ;;
+            datapart=*) UT_USERDATA_REAL=${x#*=}; UT_USERDATA=${UT_USERDATA_REAL/\/dev/\/dev\/block} ;;
+        esac
+    done
+    if [ ! -b "$UT_ROOTFS" ] || [ ! -b "$UT_USERDATA" ]; then
+        echo "abm: UT rootfs ($UT_ROOTFS) or userdata ($UT_USERDATA) multi-boot partition doesn't exist"
+        exit 1
+    fi
+    if [ "$bootset_just_mounted" ]; then
+        setprop ro.build.ab_update true 2>/dev/null # show current A/B slot
+        setprop ro.abm.extra_cmdline "rootdelay=10 systempart=$UT_ROOTFS_REAL datapart=$UT_USERDATA_REAL"
+    fi
+}
+
+fixup_fstab() {
+    fstab=/etc/recovery.fstab
+    if ! is_multiboot; then
+        echo "abm: not multi-booted, leaving $fstab alone"
+        exit 0
+    fi
+
+    setup_bootset
+
+    echo "abm: tweaking $fstab for multi-boot rootfs ($UT_ROOTFS) & userdata ($UT_USERDATA)..."
+    real_userdata="$(awk '$2=="/data" {print $1}' $fstab)" # /dev/block/by-name/userdata
+    new_entry="$(awk "\$2==\"/data\" {\$1=\"$UT_USERDATA\"; print \$0}" $fstab)" # /dev/block/mmcblk0p3 /data ext4 ...
+    sed -i "/^${real_userdata//\//\\\/}/d" $fstab
+    echo "$new_entry" >> $fstab
+
+    real_system_mnt=$(grep "^[^#].*\(/mnt\)*/system\(_root\)* " $fstab | head -1 | awk '{print $2}') # /system
+    new_entry="$(awk "\$2==\"$real_system_mnt\" {\$1=\"$UT_ROOTFS\"; sub(\"slotselect,\",\"\",\$0); sub(\"logical,\",\"\",\$0); print \$0}" $fstab)"
+    sed -i "/ ${real_system_mnt//\//\\\/} /d" $fstab
+    echo "$new_entry" >> $fstab
+    exit 0
+}
+
+case "$1" in
+    "is-multiboot") is_multiboot; exit $? ;;
+    "fixup-fstab") fixup_fstab ;;
+esac
+setup_bootset
+case "$1" in
+    "print-conf") echo "$UT_CONF" ;;
+esac

--- a/ubports/mkbootimg/Android.bp
+++ b/ubports/mkbootimg/Android.bp
@@ -1,0 +1,12 @@
+//
+// Copyright (C) 2026 The UBports Project
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+cc_binary {
+    name: "unpackbootimg_ubports",
+    stem: "unpackbootimg",
+    srcs: ["unpackbootimg.c"],
+    recovery: true,
+}

--- a/ubports/mkbootimg/bootimg.h
+++ b/ubports/mkbootimg/bootimg.h
@@ -1,0 +1,557 @@
+/*
+ * Copyright (C) 2007 The Android Open Source Project
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#define BOOT_MAGIC "ANDROID!"
+#define BOOT_MAGIC_SIZE 8
+#define BOOT_NAME_SIZE 16
+#define BOOT_ARGS_SIZE 512
+#define BOOT_EXTRA_ARGS_SIZE 1024
+
+#define VENDOR_BOOT_MAGIC "VNDRBOOT"
+#define VENDOR_BOOT_MAGIC_SIZE 8
+#define VENDOR_BOOT_ARGS_SIZE 2048
+#define VENDOR_BOOT_NAME_SIZE 16
+
+#define VENDOR_RAMDISK_TYPE_NONE 0
+#define VENDOR_RAMDISK_TYPE_PLATFORM 1
+#define VENDOR_RAMDISK_TYPE_RECOVERY 2
+#define VENDOR_RAMDISK_TYPE_DLKM 3
+#define VENDOR_RAMDISK_NAME_SIZE 32
+#define VENDOR_RAMDISK_TABLE_ENTRY_BOARD_ID_SIZE 16
+
+/*
+ * It is expected that callers would explicitly specify which version of the
+ * boot image header they need to use.
+ */
+typedef struct boot_img_hdr_v0 boot_img_hdr;
+typedef struct boot_img_hdr_v0 boot_img_hdr_v0;
+typedef struct boot_img_hdr_v1 boot_img_hdr_v1;
+typedef struct boot_img_hdr_v2 boot_img_hdr_v2;
+typedef struct boot_img_hdr_v3 boot_img_hdr_v3;
+typedef struct boot_img_hdr_v4 boot_img_hdr_v4;
+typedef struct vendor_boot_img_hdr_v3 vendor_boot_img_hdr_v3;
+typedef struct vendor_boot_img_hdr_v4 vendor_boot_img_hdr_v4;
+typedef struct vendor_ramdisk_table_entry_v4 vendor_ramdisk_table_entry_v4;
+
+/* When a boot header is of version 0, the structure of boot image is as
+ * follows:
+ *
+ * +-----------------+
+ * | boot header     | 1 page
+ * +-----------------+
+ * | kernel          | n pages
+ * +-----------------+
+ * | ramdisk         | m pages
+ * +-----------------+
+ * | second stage    | o pages
+ * +-----------------+
+ *
+ * and on some hardware:
+ * +-----------------+
+ * | device tree     | p pages
+ * +-----------------+
+ *
+ * n = (kernel_size + page_size - 1) / page_size
+ * m = (ramdisk_size + page_size - 1) / page_size
+ * o = (second_size + page_size - 1) / page_size
+ *
+ * and on some hardware:
+ * p = (dt_size + page_size - 1) / page_size
+ *
+ * 0. all entities are page_size aligned in flash
+ * 1. kernel and ramdisk are required (size != 0)
+ * 2. second is optional (second_size == 0 -> no second)
+ * 3. load each element (kernel, ramdisk, second) at
+ *    the specified physical address (kernel_addr, etc)
+ * 4. prepare tags at tag_addr.  kernel_args[] is
+ *    appended to the kernel commandline in the tags.
+ * 5. r0 = 0, r1 = MACHINE_TYPE, r2 = tags_addr
+ * 6. if second_size != 0: jump to second_addr
+ *    else: jump to kernel_addr
+ */
+struct boot_img_hdr_v0 {
+    // Must be BOOT_MAGIC.
+    uint8_t magic[BOOT_MAGIC_SIZE];
+
+    uint32_t kernel_size; /* size in bytes */
+    uint32_t kernel_addr; /* physical load addr */
+
+    uint32_t ramdisk_size; /* size in bytes */
+    uint32_t ramdisk_addr; /* physical load addr */
+
+    uint32_t second_size; /* size in bytes */
+    uint32_t second_addr; /* physical load addr */
+
+    uint32_t tags_addr; /* physical addr for kernel tags (if required) */
+    uint32_t page_size; /* flash page size we assume */
+
+    // Version of the boot image header.
+    // Alternately this is used as device tree size on some hardware.
+    union {
+        uint32_t header_version;
+        uint32_t dt_size; /* size in bytes */
+    };
+
+    // Operating system version and security patch level.
+    // For version "A.B.C" and patch level "Y-M-D":
+    //   (7 bits for each of A, B, C; 7 bits for (Y-2000), 4 bits for M)
+    //   os_version = A[31:25] B[24:18] C[17:11] (Y-2000)[10:4] M[3:0]
+    uint32_t os_version;
+
+    uint8_t name[BOOT_NAME_SIZE]; /* asciiz product name */
+
+    uint8_t cmdline[BOOT_ARGS_SIZE]; /* asciiz kernel commandline */
+
+    uint32_t id[8]; /* timestamp / checksum / sha1 / etc */
+
+    // Supplemental command line data; kept here to maintain
+    // binary compatibility with older versions of mkbootimg.
+    // Asciiz.
+    uint8_t extra_cmdline[BOOT_EXTRA_ARGS_SIZE];
+} __attribute__((packed));
+
+/* When a boot header is of version 1, the structure of boot image is as
+ * follows:
+ *
+ * +---------------------+
+ * | boot header         | 1 page
+ * +---------------------+
+ * | kernel              | n pages
+ * +---------------------+
+ * | ramdisk             | m pages
+ * +---------------------+
+ * | second stage        | o pages
+ * +---------------------+
+ * | recovery dtbo/acpio | p pages
+ * +---------------------+
+
+ * n = (kernel_size + page_size - 1) / page_size
+ * m = (ramdisk_size + page_size - 1) / page_size
+ * o = (second_size + page_size - 1) / page_size
+ * p = (recovery_dtbo_size + page_size - 1) / page_size
+ *
+ * 0. all entities are page_size aligned in flash
+ * 1. kernel and ramdisk are required (size != 0)
+ * 2. recovery_dtbo/recovery_acpio is required for recovery.img in non-A/B
+ *    devices(recovery_dtbo_size != 0)
+ * 3. second is optional (second_size == 0 -> no second)
+ * 4. load each element (kernel, ramdisk, second) at
+ *    the specified physical address (kernel_addr, etc)
+ * 5. If booting to recovery mode in a non-A/B device, extract recovery
+ *    dtbo/acpio and apply the correct set of overlays on the base device tree
+ *    depending on the hardware/product revision.
+ * 6. set up registers for kernel entry as required by your architecture
+ * 7. if second_size != 0: jump to second_addr
+ *    else: jump to kernel_addr
+ */
+struct boot_img_hdr_v1 {
+    // Must be BOOT_MAGIC.
+    uint8_t magic[BOOT_MAGIC_SIZE];
+
+    uint32_t kernel_size; /* size in bytes */
+    uint32_t kernel_addr; /* physical load addr */
+
+    uint32_t ramdisk_size; /* size in bytes */
+    uint32_t ramdisk_addr; /* physical load addr */
+
+    uint32_t second_size; /* size in bytes */
+    uint32_t second_addr; /* physical load addr */
+
+    uint32_t tags_addr; /* physical addr for kernel tags (if required) */
+    uint32_t page_size; /* flash page size we assume */
+
+    // Version of the boot image header.
+    // Alternately this is used as device tree size on some hardware.
+    // Kept here for backwards compatibility.
+    union {
+        uint32_t header_version;
+        uint32_t dt_size; /* size in bytes */
+    };
+
+    // Operating system version and security patch level.
+    // For version "A.B.C" and patch level "Y-M-D":
+    //   (7 bits for each of A, B, C; 7 bits for (Y-2000), 4 bits for M)
+    //   os_version = A[31:25] B[24:18] C[17:11] (Y-2000)[10:4] M[3:0]
+    uint32_t os_version;
+
+    uint8_t name[BOOT_NAME_SIZE]; /* asciiz product name */
+
+    uint8_t cmdline[BOOT_ARGS_SIZE]; /* asciiz kernel commandline */
+
+    uint32_t id[8]; /* timestamp / checksum / sha1 / etc */
+
+    // Supplemental command line data; kept here to maintain
+    // binary compatibility with older versions of mkbootimg.
+    // Asciiz.
+    uint8_t extra_cmdline[BOOT_EXTRA_ARGS_SIZE];
+
+    uint32_t recovery_dtbo_size;   /* size in bytes for recovery DTBO/ACPIO image */
+    uint64_t recovery_dtbo_offset; /* offset to recovery dtbo/acpio in boot image */
+    uint32_t header_size;
+} __attribute__((packed));
+
+/* When the boot image header has a version of 2, the structure of the boot
+ * image is as follows:
+ *
+ * +---------------------+
+ * | boot header         | 1 page
+ * +---------------------+
+ * | kernel              | n pages
+ * +---------------------+
+ * | ramdisk             | m pages
+ * +---------------------+
+ * | second stage        | o pages
+ * +---------------------+
+ * | recovery dtbo/acpio | p pages
+ * +---------------------+
+ * | dtb                 | q pages
+ * +---------------------+
+
+ * n = (kernel_size + page_size - 1) / page_size
+ * m = (ramdisk_size + page_size - 1) / page_size
+ * o = (second_size + page_size - 1) / page_size
+ * p = (recovery_dtbo_size + page_size - 1) / page_size
+ * q = (dtb_size + page_size - 1) / page_size
+ *
+ * 0. all entities are page_size aligned in flash
+ * 1. kernel, ramdisk and DTB are required (size != 0)
+ * 2. recovery_dtbo/recovery_acpio is required for recovery.img in non-A/B
+ *    devices(recovery_dtbo_size != 0)
+ * 3. second is optional (second_size == 0 -> no second)
+ * 4. load each element (kernel, ramdisk, second, dtb) at
+ *    the specified physical address (kernel_addr, etc)
+ * 5. If booting to recovery mode in a non-A/B device, extract recovery
+ *    dtbo/acpio and apply the correct set of overlays on the base device tree
+ *    depending on the hardware/product revision.
+ * 6. set up registers for kernel entry as required by your architecture
+ * 7. if second_size != 0: jump to second_addr
+ *    else: jump to kernel_addr
+ */
+struct boot_img_hdr_v2 {
+    // Must be BOOT_MAGIC.
+    uint8_t magic[BOOT_MAGIC_SIZE];
+
+    uint32_t kernel_size; /* size in bytes */
+    uint32_t kernel_addr; /* physical load addr */
+
+    uint32_t ramdisk_size; /* size in bytes */
+    uint32_t ramdisk_addr; /* physical load addr */
+
+    uint32_t second_size; /* size in bytes */
+    uint32_t second_addr; /* physical load addr */
+
+    uint32_t tags_addr; /* physical addr for kernel tags (if required) */
+    uint32_t page_size; /* flash page size we assume */
+
+    // Version of the boot image header.
+    // Alternately this is used as device tree size on some hardware.
+    // Kept here for backwards compatibility.
+    union {
+        uint32_t header_version;
+        uint32_t dt_size; /* size in bytes */
+    };
+
+    // Operating system version and security patch level.
+    // For version "A.B.C" and patch level "Y-M-D":
+    //   (7 bits for each of A, B, C; 7 bits for (Y-2000), 4 bits for M)
+    //   os_version = A[31:25] B[24:18] C[17:11] (Y-2000)[10:4] M[3:0]
+    uint32_t os_version;
+
+    uint8_t name[BOOT_NAME_SIZE]; /* asciiz product name */
+
+    uint8_t cmdline[BOOT_ARGS_SIZE]; /* asciiz kernel commandline */
+
+    uint32_t id[8]; /* timestamp / checksum / sha1 / etc */
+
+    // Supplemental command line data; kept here to maintain
+    // binary compatibility with older versions of mkbootimg.
+    // Asciiz.
+    uint8_t extra_cmdline[BOOT_EXTRA_ARGS_SIZE];
+
+    uint32_t recovery_dtbo_size;   /* size in bytes for recovery DTBO/ACPIO image */
+    uint64_t recovery_dtbo_offset; /* offset to recovery dtbo/acpio in boot image */
+    uint32_t header_size;
+
+    uint32_t dtb_size; /* size in bytes for DTB image */
+    uint64_t dtb_addr; /* physical load address for DTB image */
+} __attribute__((packed));
+
+/* When the boot image header has a version of 3, the structure of the boot
+ * image is as follows:
+ *
+ * +---------------------+
+ * | boot header         | 4096 bytes
+ * +---------------------+
+ * | kernel              | m pages
+ * +---------------------+
+ * | ramdisk             | n pages
+ * +---------------------+
+ *
+ * m = (kernel_size + 4096 - 1) / 4096
+ * n = (ramdisk_size + 4096 - 1) / 4096
+ *
+ * Note that in version 3 of the boot image header, page size is fixed at 4096 bytes.
+ *
+ * The structure of the vendor boot image (introduced with version 3 and
+ * required to be present when a v3 boot image is used) is as follows:
+ *
+ * +---------------------+
+ * | vendor boot header  | o pages
+ * +---------------------+
+ * | vendor ramdisk      | p pages
+ * +---------------------+
+ * | dtb                 | q pages
+ * +---------------------+
+
+ * o = (2112 + page_size - 1) / page_size
+ * p = (vendor_ramdisk_size + page_size - 1) / page_size
+ * q = (dtb_size + page_size - 1) / page_size
+ *
+ * 0. all entities in the boot image are 4096-byte aligned in flash, all
+ *    entities in the vendor boot image are page_size (determined by the vendor
+ *    and specified in the vendor boot image header) aligned in flash
+ * 1. kernel, ramdisk, vendor ramdisk, and DTB are required (size != 0)
+ * 2. load the kernel and DTB at the specified physical address (kernel_addr,
+ *    dtb_addr)
+ * 3. load the vendor ramdisk at ramdisk_addr
+ * 4. load the generic ramdisk immediately following the vendor ramdisk in
+ *    memory
+ * 5. set up registers for kernel entry as required by your architecture
+ * 6. if the platform has a second stage bootloader jump to it (must be
+ *    contained outside boot and vendor boot partitions), otherwise
+ *    jump to kernel_addr
+ */
+struct boot_img_hdr_v3 {
+    // Must be BOOT_MAGIC.
+    uint8_t magic[BOOT_MAGIC_SIZE];
+
+    uint32_t kernel_size; /* size in bytes */
+    uint32_t ramdisk_size; /* size in bytes */
+
+    // Operating system version and security patch level.
+    // For version "A.B.C" and patch level "Y-M-D":
+    //   (7 bits for each of A, B, C; 7 bits for (Y-2000), 4 bits for M)
+    //   os_version = A[31:25] B[24:18] C[17:11] (Y-2000)[10:4] M[3:0]
+    uint32_t os_version;
+
+    uint32_t header_size;
+
+    uint32_t reserved[4];
+
+    // Version of the boot image header.
+    uint32_t header_version;
+
+    // Asciiz kernel commandline.
+    uint8_t cmdline[BOOT_ARGS_SIZE + BOOT_EXTRA_ARGS_SIZE];
+} __attribute__((packed));
+
+struct vendor_boot_img_hdr_v3 {
+    // Must be VENDOR_BOOT_MAGIC.
+    uint8_t magic[VENDOR_BOOT_MAGIC_SIZE];
+
+    // Version of the vendor boot image header.
+    uint32_t header_version;
+
+    uint32_t page_size; /* flash page size we assume */
+
+    uint32_t kernel_addr; /* physical load addr */
+    uint32_t ramdisk_addr; /* physical load addr */
+
+    uint32_t vendor_ramdisk_size; /* size in bytes */
+
+    uint8_t cmdline[VENDOR_BOOT_ARGS_SIZE]; /* asciiz kernel commandline */
+
+    uint32_t tags_addr; /* physical addr for kernel tags (if required) */
+    uint8_t name[VENDOR_BOOT_NAME_SIZE]; /* asciiz product name */
+
+    uint32_t header_size;
+
+    uint32_t dtb_size; /* size in bytes for DTB image */
+    uint64_t dtb_addr; /* physical load address for DTB image */
+} __attribute__((packed));
+
+/* When the boot image header has a version of 4, the structure of the boot
+ * image is as follows:
+ *
+ * +---------------------+
+ * | boot header         | 4096 bytes
+ * +---------------------+
+ * | kernel              | m pages
+ * +---------------------+
+ * | ramdisk             | n pages
+ * +---------------------+
+ * | boot signature      | g pages
+ * +---------------------+
+ *
+ * m = (kernel_size + 4096 - 1) / 4096
+ * n = (ramdisk_size + 4096 - 1) / 4096
+ * g = (signature_size + 4096 - 1) / 4096
+ *
+ * Note that in version 4 of the boot image header, page size is fixed at 4096
+ * bytes.
+ *
+ * The structure of the vendor boot image version 4, which is required to be
+ * present when a version 4 boot image is used, is as follows:
+ *
+ * +------------------------+
+ * | vendor boot header     | o pages
+ * +------------------------+
+ * | vendor ramdisk section | p pages
+ * +------------------------+
+ * | dtb                    | q pages
+ * +------------------------+
+ * | vendor ramdisk table   | r pages
+ * +------------------------+
+ * | bootconfig             | s pages
+ * +------------------------+
+ *
+ * o = (2128 + page_size - 1) / page_size
+ * p = (vendor_ramdisk_size + page_size - 1) / page_size
+ * q = (dtb_size + page_size - 1) / page_size
+ * r = (vendor_ramdisk_table_size + page_size - 1) / page_size
+ * s = (vendor_bootconfig_size + page_size - 1) / page_size
+ *
+ * Note that in version 4 of the vendor boot image, multiple vendor ramdisks can
+ * be included in the vendor boot image. The bootloader can select a subset of
+ * ramdisks to load at runtime. To help the bootloader select the ramdisks, each
+ * ramdisk is tagged with a type tag and a set of hardware identifiers
+ * describing the board, soc or platform that this ramdisk is intended for.
+ *
+ * The vendor ramdisk section is consist of multiple ramdisk images concatenated
+ * one after another, and vendor_ramdisk_size is the size of the section, which
+ * is the total size of all the ramdisks included in the vendor boot image.
+ *
+ * The vendor ramdisk table holds the size, offset, type, name and hardware
+ * identifiers of each ramdisk. The type field denotes the type of its content.
+ * The vendor ramdisk names are unique. The hardware identifiers are specified
+ * in the board_id field in each table entry. The board_id field is consist of a
+ * vector of unsigned integer words, and the encoding scheme is defined by the
+ * hardware vendor.
+ *
+ * For the different type of ramdisks, there are:
+ *    - VENDOR_RAMDISK_TYPE_NONE indicates the value is unspecified.
+ *    - VENDOR_RAMDISK_TYPE_PLATFORM ramdisks contain platform specific bits, so
+ *      the bootloader should always load these into memory.
+ *    - VENDOR_RAMDISK_TYPE_RECOVERY ramdisks contain recovery resources, so
+ *      the bootloader should load these when booting into recovery.
+ *    - VENDOR_RAMDISK_TYPE_DLKM ramdisks contain dynamic loadable kernel
+ *      modules.
+ *
+ * Version 4 of the vendor boot image also adds a bootconfig section to the end
+ * of the image. This section contains Boot Configuration parameters known at
+ * build time. The bootloader is responsible for placing this section directly
+ * after the generic ramdisk, followed by the bootconfig trailer, before
+ * entering the kernel.
+ *
+ * 0. all entities in the boot image are 4096-byte aligned in flash, all
+ *    entities in the vendor boot image are page_size (determined by the vendor
+ *    and specified in the vendor boot image header) aligned in flash
+ * 1. kernel, ramdisk, and DTB are required (size != 0)
+ * 2. load the kernel and DTB at the specified physical address (kernel_addr,
+ *    dtb_addr)
+ * 3. load the vendor ramdisks at ramdisk_addr
+ * 4. load the generic ramdisk immediately following the vendor ramdisk in
+ *    memory
+ * 5. load the bootconfig immediately following the generic ramdisk. Add
+ *    additional bootconfig parameters followed by the bootconfig trailer.
+ * 6. set up registers for kernel entry as required by your architecture
+ * 7. if the platform has a second stage bootloader jump to it (must be
+ *    contained outside boot and vendor boot partitions), otherwise
+ *    jump to kernel_addr
+ */
+struct boot_img_hdr_v4 {
+    // Must be BOOT_MAGIC.
+    uint8_t magic[BOOT_MAGIC_SIZE];
+
+    uint32_t kernel_size; /* size in bytes */
+    uint32_t ramdisk_size; /* size in bytes */
+
+    // Operating system version and security patch level.
+    // For version "A.B.C" and patch level "Y-M-D":
+    //   (7 bits for each of A, B, C; 7 bits for (Y-2000), 4 bits for M)
+    //   os_version = A[31:25] B[24:18] C[17:11] (Y-2000)[10:4] M[3:0]
+    uint32_t os_version;
+
+    uint32_t header_size;
+
+    uint32_t reserved[4];
+
+    // Version of the boot image header.
+    uint32_t header_version;
+
+    // Asciiz kernel commandline.
+    uint8_t cmdline[BOOT_ARGS_SIZE + BOOT_EXTRA_ARGS_SIZE];
+
+    uint32_t signature_size; /* size in bytes */
+} __attribute__((packed));
+
+struct vendor_boot_img_hdr_v4 {
+    // Must be VENDOR_BOOT_MAGIC.
+    uint8_t magic[VENDOR_BOOT_MAGIC_SIZE];
+
+    // Version of the vendor boot image header.
+    uint32_t header_version;
+
+    uint32_t page_size; /* flash page size we assume */
+
+    uint32_t kernel_addr; /* physical load addr */
+    uint32_t ramdisk_addr; /* physical load addr */
+
+    uint32_t vendor_ramdisk_size; /* size in bytes */
+
+    uint8_t cmdline[VENDOR_BOOT_ARGS_SIZE]; /* asciiz kernel commandline */
+
+    uint32_t tags_addr; /* physical addr for kernel tags (if required) */
+    uint8_t name[VENDOR_BOOT_NAME_SIZE]; /* asciiz product name */
+
+    uint32_t header_size;
+
+    uint32_t dtb_size; /* size in bytes for DTB image */
+    uint64_t dtb_addr; /* physical load address for DTB image */
+
+    uint32_t vendor_ramdisk_table_size; /* size in bytes for the vendor ramdisk table */
+    uint32_t vendor_ramdisk_table_entry_num; /* number of entries in the vendor ramdisk table */
+    uint32_t vendor_ramdisk_table_entry_size; /* size in bytes for a vendor ramdisk table entry */
+    uint32_t bootconfig_size; /* size in bytes for the bootconfig section */
+} __attribute__((packed));
+
+struct vendor_ramdisk_table_entry_v4 {
+    uint32_t ramdisk_size; /* size in bytes for the ramdisk image */
+    uint32_t ramdisk_offset; /* offset to the ramdisk image in vendor ramdisk section */
+    uint32_t ramdisk_type; /* type of the ramdisk */
+    uint8_t ramdisk_name[VENDOR_RAMDISK_NAME_SIZE]; /* asciiz ramdisk name */
+
+    // Hardware identifiers describing the board, soc or platform which this
+    // ramdisk is intended to be loaded on.
+    uint32_t board_id[VENDOR_RAMDISK_TABLE_ENTRY_BOARD_ID_SIZE];
+} __attribute__((packed));

--- a/ubports/mkbootimg/mincrypt/hash-internal.h
+++ b/ubports/mkbootimg/mincrypt/hash-internal.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2007 The Android Open Source Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Google Inc. nor the names of its contributors may
+ *       be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY Google Inc. ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL Google Inc. BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SYSTEM_CORE_INCLUDE_MINCRYPT_HASH_INTERNAL_H_
+#define SYSTEM_CORE_INCLUDE_MINCRYPT_HASH_INTERNAL_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+struct HASH_CTX;  // forward decl
+
+typedef struct HASH_VTAB {
+  void (* const init)(struct HASH_CTX*);
+  void (* const update)(struct HASH_CTX*, const void*, int);
+  const uint8_t* (* const final)(struct HASH_CTX*);
+  const uint8_t* (* const hash)(const void*, int, uint8_t*);
+  int size;
+} HASH_VTAB;
+
+typedef struct HASH_CTX {
+  const HASH_VTAB * f;
+  uint64_t count;
+  uint8_t buf[64];
+  uint32_t state[8];  // upto SHA2
+} HASH_CTX;
+
+#define HASH_init(ctx) (ctx)->f->init(ctx)
+#define HASH_update(ctx, data, len) (ctx)->f->update(ctx, data, len)
+#define HASH_final(ctx) (ctx)->f->final(ctx)
+#define HASH_hash(data, len, digest) (ctx)->f->hash(data, len, digest)
+#define HASH_size(ctx) (ctx)->f->size
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // SYSTEM_CORE_INCLUDE_MINCRYPT_HASH_INTERNAL_H_

--- a/ubports/mkbootimg/mincrypt/sha.h
+++ b/ubports/mkbootimg/mincrypt/sha.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2005 The Android Open Source Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Google Inc. nor the names of its contributors may
+ *       be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY Google Inc. ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL Google Inc. BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SYSTEM_CORE_INCLUDE_MINCRYPT_SHA1_H_
+#define SYSTEM_CORE_INCLUDE_MINCRYPT_SHA1_H_
+
+#include <stdint.h>
+#include "hash-internal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+typedef HASH_CTX SHA_CTX;
+
+void SHA_init(SHA_CTX* ctx);
+void SHA_update(SHA_CTX* ctx, const void* data, int len);
+const uint8_t* SHA_final(SHA_CTX* ctx);
+
+// Convenience method. Returns digest address.
+// NOTE: *digest needs to hold SHA_DIGEST_SIZE bytes.
+const uint8_t* SHA_hash(const void* data, int len, uint8_t* digest);
+
+#define SHA_DIGEST_SIZE 20
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#endif  // SYSTEM_CORE_INCLUDE_MINCRYPT_SHA1_H_

--- a/ubports/mkbootimg/mincrypt/sha256.h
+++ b/ubports/mkbootimg/mincrypt/sha256.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2011 The Android Open Source Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Google Inc. nor the names of its contributors may
+ *       be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY Google Inc. ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL Google Inc. BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SYSTEM_CORE_INCLUDE_MINCRYPT_SHA256_H_
+#define SYSTEM_CORE_INCLUDE_MINCRYPT_SHA256_H_
+
+#include <stdint.h>
+#include "hash-internal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+typedef HASH_CTX SHA256_CTX;
+
+void SHA256_init(SHA256_CTX* ctx);
+void SHA256_update(SHA256_CTX* ctx, const void* data, int len);
+const uint8_t* SHA256_final(SHA256_CTX* ctx);
+
+// Convenience method. Returns digest address.
+const uint8_t* SHA256_hash(const void* data, int len, uint8_t* digest);
+
+#define SHA256_DIGEST_SIZE 32
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#endif  // SYSTEM_CORE_INCLUDE_MINCRYPT_SHA256_H_

--- a/ubports/mkbootimg/unpackbootimg.c
+++ b/ubports/mkbootimg/unpackbootimg.c
@@ -1,0 +1,439 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <limits.h>
+#include <libgen.h>
+#include <inttypes.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include "mincrypt/sha.h"
+#include "mincrypt/sha256.h"
+#include "bootimg.h"
+
+typedef unsigned char byte;
+
+char *directory = "./";
+char *filename = NULL;
+int debug = 0;
+
+int total_read = 0;
+
+int pagesize = 0;
+int a = 0, b = 0, c = 0, y = 0, m = 0; // header.os_version component calculation variables
+
+int read_padding(FILE *f, unsigned itemsize)
+{
+    byte *buf = (byte *)malloc(sizeof(byte) * pagesize);
+    unsigned pagemask = pagesize - 1;
+    unsigned count;
+    if((itemsize & pagemask) == 0) {
+        free(buf);
+        return 0;
+    }
+    count = pagesize - (itemsize & pagemask);
+    if(fread(buf, count, 1, f)) {};
+    free(buf);
+    if(debug > 1) fprintf(stderr, "read padding: %d\n", count);
+    return count;
+}
+
+void write_string_to_file(const char *name, const char *string)
+{
+    char file[PATH_MAX];
+    sprintf(file, "%s/%s-%s", directory, basename(filename), name);
+    FILE *t = fopen(file, "w");
+    if(debug > 0) fprintf(stderr, "%s...\n", name);
+    fwrite(string, strlen(string), 1, t);
+    fwrite("\n", 1, 1, t);
+    fclose(t);
+}
+
+void write_buffer_to_file(const char *name, FILE *f, const int size)
+{
+    char file[PATH_MAX];
+    sprintf(file, "%s/%s-%s", directory, basename(filename), name);
+    FILE *t = fopen(file, "wb");
+    byte *buf = (byte *)malloc(size);
+    if(debug > 0) fprintf(stderr, "Reading %s...\n", name);
+    if(fread(buf, size, 1, f)) {};
+    total_read += size;
+    if(debug > 1) fprintf(stderr, "read: %d\n", size);
+    fwrite(buf, size, 1, t);
+    fclose(t);
+    free(buf);
+    total_read += read_padding(f, size);
+}
+
+const char *detect_hash_type(boot_img_hdr_v2 *hdr)
+{
+    // sha1 is expected to have zeroes in id[20] and higher
+    // offset by 4 to accomodate bootimg variants with BOOT_NAME_SIZE 20
+    uint8_t id[SHA256_DIGEST_SIZE];
+    memcpy(&id, hdr->id, sizeof(id));
+    int i;
+    for(i = SHA_DIGEST_SIZE + 4; i < SHA256_DIGEST_SIZE; ++i) {
+        if(id[i]) {
+            return "sha256";
+        }
+    }
+    return "sha1";
+}
+
+int print_os_version(uint32_t hdr_os_ver)
+{
+    if(hdr_os_ver != 0) {
+        int os_version = 0, os_patch_level = 0;
+        os_version = hdr_os_ver >> 11;
+        os_patch_level = hdr_os_ver&0x7ff;
+
+        a = (os_version >> 14)&0x7f;
+        b = (os_version >> 7)&0x7f;
+        c = os_version&0x7f;
+
+        y = (os_patch_level >> 4) + 2000;
+        m = os_patch_level&0xf;
+    }
+    if((a < 128) && (b < 128) && (c < 128) && (y >= 2000) && (y < 2128) && (m > 0) && (m <= 12)) {
+        printf("BOARD_OS_VERSION %d.%d.%d\n", a, b, c);
+        printf("BOARD_OS_PATCH_LEVEL %d-%02d\n", y, m);
+        return 0;
+    }
+    return 1;
+}
+
+int usage(void)
+{
+    fprintf(stderr,
+        "usage: unpackbootimg\n"
+        "\t-i|--input <filename>\n"
+        "\t[ -o|--output <directory> | -h|--header-only ]\n"
+        "\t[ -p|--pagesize <size-in-hexadecimal> ]\n"
+    );
+    if(debug > 0) fprintf(stderr, "\t[ -d|--debug <debug-level> ]\n");
+    return 1;
+}
+
+int main(int argc, char **argv)
+{
+    char tmp[BOOT_MAGIC_SIZE];
+    char *magic = NULL;
+    int base = 0;
+
+    int headeronly = 0;
+
+    int seeklimit = 65536; // arbitrary byte limit to search in input file for ANDROID!/VNDRBOOT magic
+    int hdr_ver_max = 8; // arbitrary maximum header version value; when greater assume the field is appended dt size
+
+    argc--;
+    argv++;
+    while(argc > 0) {
+        char *arg = argv[0];
+        char *val = argv[1];
+        argc -= 2;
+        argv += 2;
+        if(!strcmp(arg, "--input") || !strcmp(arg, "-i")) {
+            filename = val;
+        } else if(!strcmp(arg, "--output") || !strcmp(arg, "-o")) {
+            directory = val;
+        } else if(!strcmp(arg, "--pagesize") || !strcmp(arg, "-p")) {
+            pagesize = strtoul(val, 0, 16);
+        } else if(!strcmp(arg, "--header-only") || !strcmp(arg, "-h")) {
+            headeronly = 1;
+        } else if(!strcmp(arg, "--debug") || !strcmp(arg, "-d")) {
+            debug = strtoul(val, 0, 10);
+        } else {
+            return usage();
+        }
+    }
+
+    if(filename == NULL) {
+        return usage();
+    }
+
+    struct stat st;
+    if(stat(directory, &st) == (-1)) {
+        fprintf(stderr, "Could not stat %s: %s\n", directory, strerror(errno));
+        return 1;
+    }
+    if(!S_ISDIR(st.st_mode)) {
+        fprintf(stderr, "%s is not a directory\n", directory);
+        return 1;
+    }
+
+    FILE *f = fopen(filename, "rb");
+    if(!f) {
+        fprintf(stderr, "Could not open input file: %s\n", strerror(errno));
+        return 1;
+    }
+
+    if(debug > 0) fprintf(stderr, "Reading header...\n");
+    int i;
+    for(i = 0; i <= seeklimit; i++) {
+        fseek(f, i, SEEK_SET);
+        if(fread(tmp, BOOT_MAGIC_SIZE, 1, f)) {};
+        if(memcmp(tmp, BOOT_MAGIC, BOOT_MAGIC_SIZE) == 0) {
+            magic = BOOT_MAGIC;
+            break;
+        }
+        if(memcmp(tmp, VENDOR_BOOT_MAGIC, VENDOR_BOOT_MAGIC_SIZE) == 0) {
+            magic = VENDOR_BOOT_MAGIC;
+            break;
+        }
+    }
+    total_read = i;
+    if(i > seeklimit) {
+        fprintf(stderr, "Boot image magic not found.\n");
+        return 1;
+    }
+    printf("%s magic found at: %d\n", magic, i);
+
+    boot_img_hdr_v3 header;
+    fseek(f, i, SEEK_SET);
+    if(fread(&header, sizeof(header), 1, f)) {};
+
+    if(!strcmp(magic, BOOT_MAGIC)) {
+        if((header.header_version < 3) || (header.header_version > hdr_ver_max)) {
+            // boot_img_hdr_v2 in the backported header supports all boot_img_hdr versions and cross-compatible variants below 3
+
+            fseek(f, i, SEEK_SET);
+            boot_img_hdr_v2 header;
+            if(fread(&header, sizeof(header), 1, f)) {};
+
+            base = header.kernel_addr - 0x00008000;
+            if(pagesize == 0) {
+                pagesize = header.page_size;
+            }
+            const char *hash_type = detect_hash_type(&header);
+
+            printf("BOARD_KERNEL_CMDLINE %.*s%.*s\n", BOOT_ARGS_SIZE, header.cmdline, BOOT_EXTRA_ARGS_SIZE, header.extra_cmdline);
+            printf("BOARD_KERNEL_BASE 0x%08x\n", base);
+            printf("BOARD_NAME %s\n", header.name);
+            printf("BOARD_PAGE_SIZE %d\n", header.page_size);
+            printf("BOARD_HASH_TYPE %s\n", hash_type);
+            printf("BOARD_KERNEL_OFFSET 0x%08x\n", header.kernel_addr - base);
+            printf("BOARD_RAMDISK_OFFSET 0x%08x\n", header.ramdisk_addr - base);
+            printf("BOARD_SECOND_OFFSET 0x%08x\n", header.second_addr - base);
+            printf("BOARD_TAGS_OFFSET 0x%08x\n", header.tags_addr - base);
+            if(print_os_version(header.os_version) == 1) {
+                header.os_version = 0;
+            }
+            if(header.dt_size > hdr_ver_max) {
+                printf("BOARD_DT_SIZE %d\n", header.dt_size);
+            } else {
+                printf("BOARD_HEADER_VERSION %d\n", header.header_version);
+            }
+            if(header.header_version <= hdr_ver_max) {
+                if(header.header_version > 0) {
+                    if(header.recovery_dtbo_size != 0) {
+                        printf("BOARD_RECOVERY_DTBO_SIZE %d\n", header.recovery_dtbo_size);
+                        printf("BOARD_RECOVERY_DTBO_OFFSET %"PRId64"\n", header.recovery_dtbo_offset);
+                    }
+                    printf("BOARD_HEADER_SIZE %d\n", header.header_size);
+                } else {
+                    header.recovery_dtbo_size = 0;
+                }
+                if(header.header_version > 1) {
+                    if(header.dtb_size != 0) {
+                        printf("BOARD_DTB_SIZE %d\n", header.dtb_size);
+                        printf("BOARD_DTB_OFFSET 0x%08"PRIx64"\n", header.dtb_addr - base);
+                    }
+                } else {
+                    header.dtb_size = 0;
+                }
+            }
+            if(headeronly == 1) return 0;
+
+            char cmdlinetmp[BOOT_ARGS_SIZE+BOOT_EXTRA_ARGS_SIZE+1];
+            sprintf(cmdlinetmp, "%.*s%.*s", BOOT_ARGS_SIZE, header.cmdline, BOOT_EXTRA_ARGS_SIZE, header.extra_cmdline);
+            cmdlinetmp[BOOT_ARGS_SIZE+BOOT_EXTRA_ARGS_SIZE]='\0';
+            write_string_to_file("cmdline", cmdlinetmp);
+
+            write_string_to_file("board", (char *)header.name);
+
+            char basetmp[200];
+            sprintf(basetmp, "0x%08x", base);
+            write_string_to_file("base", basetmp);
+
+            char pagesizetmp[200];
+            sprintf(pagesizetmp, "%d", header.page_size);
+            write_string_to_file("pagesize", pagesizetmp);
+
+            char kernelofftmp[200];
+            sprintf(kernelofftmp, "0x%08x", header.kernel_addr - base);
+            write_string_to_file("kernel_offset", kernelofftmp);
+
+            char ramdiskofftmp[200];
+            sprintf(ramdiskofftmp, "0x%08x", header.ramdisk_addr - base);
+            write_string_to_file("ramdisk_offset", ramdiskofftmp);
+
+            char secondofftmp[200];
+            sprintf(secondofftmp, "0x%08x", header.second_addr - base);
+            write_string_to_file("second_offset", secondofftmp);
+
+            char tagsofftmp[200];
+            sprintf(tagsofftmp, "0x%08x", header.tags_addr - base);
+            write_string_to_file("tags_offset", tagsofftmp);
+
+            if(header.os_version != 0) {
+                char osvertmp[200];
+                sprintf(osvertmp, "%d.%d.%d", a, b, c);
+                write_string_to_file("os_version", osvertmp);
+
+                char oslvltmp[200];
+                sprintf(oslvltmp, "%d-%02d", y, m);
+                write_string_to_file("os_patch_level", oslvltmp);
+            }
+
+            if(header.header_version <= hdr_ver_max) {
+                char hdrvertmp[200];
+                sprintf(hdrvertmp, "%d\n", header.header_version); // extra newline to prevent some file editors from interpreting a 2-byte file as Unicode
+                write_string_to_file("header_version", hdrvertmp);
+
+                if(header.header_version > 1) {
+                    char dtbofftmp[200];
+                    sprintf(dtbofftmp, "0x%08"PRIx64, header.dtb_addr - base);
+                    write_string_to_file("dtb_offset", dtbofftmp);
+                }
+            }
+
+            write_string_to_file("hashtype", hash_type);
+
+            total_read += sizeof(header);
+            if(debug > 1) fprintf(stderr, "read: %d\n", total_read); // this will harmlessly always show 1660 since it uses boot_img_hdr_v2 for all < v3
+            total_read += read_padding(f, sizeof(header));
+
+            write_buffer_to_file("kernel", f, header.kernel_size);
+
+            write_buffer_to_file("ramdisk", f, header.ramdisk_size);
+
+            if(header.second_size != 0) {
+                write_buffer_to_file("second", f, header.second_size);
+            }
+
+            if(header.dt_size > hdr_ver_max) {
+                write_buffer_to_file("dt", f, header.dt_size);
+            } else {
+                if(header.recovery_dtbo_size != 0) {
+                    write_buffer_to_file("recovery_dtbo", f, header.recovery_dtbo_size);
+                }
+                if(header.dtb_size != 0) {
+                    write_buffer_to_file("dtb", f, header.dtb_size);
+                }
+            }
+        } else {
+            // boot_img_hdr_v3 and above are no longer backwards compatible
+
+            if(pagesize == 0) {
+                pagesize = 0x00001000; // page_size is hardcoded to 4096 in boot_img_hdr_v3 and above
+            }
+
+            printf("BOARD_KERNEL_CMDLINE %.*s\n", BOOT_ARGS_SIZE+BOOT_EXTRA_ARGS_SIZE, header.cmdline);
+            printf("BOARD_PAGE_SIZE 4096\n");
+            print_os_version(header.os_version);
+            printf("BOARD_HEADER_VERSION %d\n", header.header_version);
+            printf("BOARD_HEADER_SIZE %d\n", header.header_size);
+            if(headeronly == 1) return 0;
+
+            char cmdlinetmp[BOOT_ARGS_SIZE+BOOT_EXTRA_ARGS_SIZE+1];
+            sprintf(cmdlinetmp, "%.*s", BOOT_ARGS_SIZE+BOOT_EXTRA_ARGS_SIZE, header.cmdline);
+            cmdlinetmp[BOOT_ARGS_SIZE+BOOT_EXTRA_ARGS_SIZE]='\0';
+            write_string_to_file("cmdline", cmdlinetmp);
+
+            char osvertmp[200];
+            sprintf(osvertmp, "%d.%d.%d", a, b, c);
+            write_string_to_file("os_version", osvertmp);
+
+            char oslvltmp[200];
+            sprintf(oslvltmp, "%d-%02d", y, m);
+            write_string_to_file("os_patch_level", oslvltmp);
+
+            char hdrvertmp[200];
+            sprintf(hdrvertmp, "%d\n", header.header_version); // extra newline to prevent some file editors from interpreting a 2-byte file as Unicode
+            write_string_to_file("header_version", hdrvertmp);
+
+            total_read += sizeof(header);
+            if(debug > 1) fprintf(stderr, "read: %d\n", total_read);
+            total_read += read_padding(f, sizeof(header));
+
+            write_buffer_to_file("kernel", f, header.kernel_size);
+
+            write_buffer_to_file("ramdisk", f, header.ramdisk_size);
+        }
+    } else {
+        // vendor_boot_img_hdr started at v3 and is not cross-compatible with boot_img_hdr
+
+        fseek(f, i, SEEK_SET);
+        vendor_boot_img_hdr_v3 header;
+        if(fread(&header, sizeof(header), 1, f)) {};
+
+        base = header.kernel_addr - 0x00008000;
+        if(pagesize == 0) {
+            pagesize = header.page_size;
+        }
+
+        printf("BOARD_VENDOR_CMDLINE %.*s\n", VENDOR_BOOT_ARGS_SIZE, header.cmdline);
+        printf("BOARD_VENDOR_BASE 0x%08x\n", base);
+        printf("BOARD_NAME %s\n", header.name);
+        printf("BOARD_PAGE_SIZE %d\n", header.page_size);
+        printf("BOARD_KERNEL_OFFSET 0x%08x\n", header.kernel_addr - base);
+        printf("BOARD_RAMDISK_OFFSET 0x%08x\n", header.ramdisk_addr - base);
+        printf("BOARD_TAGS_OFFSET 0x%08x\n", header.tags_addr - base);
+        printf("BOARD_HEADER_VERSION %d\n", header.header_version);
+        printf("BOARD_HEADER_SIZE %d\n", header.header_size);
+        printf("BOARD_DTB_SIZE %d\n", header.dtb_size);
+        printf("BOARD_DTB_OFFSET 0x%08"PRIx64"\n", header.dtb_addr - base);
+        if(headeronly == 1) return 0;
+
+        char cmdlinetmp[VENDOR_BOOT_ARGS_SIZE+1];
+        sprintf(cmdlinetmp, "%.*s", VENDOR_BOOT_ARGS_SIZE, header.cmdline);
+        cmdlinetmp[VENDOR_BOOT_ARGS_SIZE]='\0';
+        write_string_to_file("vendor_cmdline", cmdlinetmp);
+
+        write_string_to_file("board", (char *)header.name);
+
+        char basetmp[200];
+        sprintf(basetmp, "0x%08x", base);
+        write_string_to_file("base", basetmp);
+
+        char pagesizetmp[200];
+        sprintf(pagesizetmp, "%d", header.page_size);
+        write_string_to_file("pagesize", pagesizetmp);
+
+        char kernelofftmp[200];
+        sprintf(kernelofftmp, "0x%08x", header.kernel_addr - base);
+        write_string_to_file("kernel_offset", kernelofftmp);
+
+        char ramdiskofftmp[200];
+        sprintf(ramdiskofftmp, "0x%08x", header.ramdisk_addr - base);
+        write_string_to_file("ramdisk_offset", ramdiskofftmp);
+
+        char tagsofftmp[200];
+        sprintf(tagsofftmp, "0x%08x", header.tags_addr - base);
+        write_string_to_file("tags_offset", tagsofftmp);
+
+        char hdrvertmp[200];
+        sprintf(hdrvertmp, "%d\n", header.header_version); // extra newline to prevent some file editors from interpreting a 2-byte file as Unicode
+        write_string_to_file("header_version", hdrvertmp);
+
+        char dtbofftmp[200];
+        sprintf(dtbofftmp, "0x%08"PRIx64, header.dtb_addr - base);
+        write_string_to_file("dtb_offset", dtbofftmp);
+
+        total_read += sizeof(header);
+        if(debug > 1) fprintf(stderr, "read: %d\n", total_read);
+        total_read += read_padding(f, sizeof(header));
+
+        write_buffer_to_file("vendor_ramdisk", f, header.vendor_ramdisk_size);
+
+        write_buffer_to_file("dtb", f, header.dtb_size);
+    }
+
+    fclose(f);
+
+    if(debug > 0) fprintf(stderr, "Total Read: %d\n", total_read);
+    return 0;
+}

--- a/ubports/setup-fake-cache
+++ b/ubports/setup-fake-cache
@@ -11,9 +11,14 @@ true|1) : ;;
 *) exit_mounted 0 ;;
 esac
 
+USERDATA=/dev/block/by-name/userdata
+if abm is-multiboot; then
+    abm fixup-fstab
+    USERDATA=$(awk '$2=="/data" {print $1}' /etc/recovery.fstab)
+fi
 RETRY_COUNTER=0
 while [ $(( RETRY_COUNTER += 1 )) -le 3 ]; do
-    mount /dev/block/by-name/userdata /data && break || sleep 1
+    mount $USERDATA /data && break || sleep 1
 done
 
 if [ $RETRY_COUNTER -eq 4 ]; then

--- a/ubports/setup-fake-cache
+++ b/ubports/setup-fake-cache
@@ -1,4 +1,5 @@
 #!/system/bin/sh
+exec > /dev/kmsg 2>&1
 
 exit_mounted() {
     setprop halium.datamount.done 1
@@ -12,14 +13,14 @@ esac
 
 RETRY_COUNTER=0
 while [ $(( RETRY_COUNTER += 1 )) -le 3 ]; do
-    mount /dev/block/by-name/userdata /data > /dev/kmsg && break || sleep 1
+    mount /dev/block/by-name/userdata /data && break || sleep 1
 done
 
 if [ $RETRY_COUNTER -eq 4 ]; then
-    echo "setup-fake-cache: reached maximum number of retries" > /dev/kmsg
+    echo "setup-fake-cache: reached maximum number of retries"
     exit_mounted 1
 fi
 
-mkdir /data/cache > /dev/kmsg
-mount -o bind /data/cache /cache > /dev/kmsg
+mkdir /data/cache
+mount -o bind /data/cache /cache
 exit_mounted 0

--- a/ubports/system-image-upgrader
+++ b/ubports/system-image-upgrader
@@ -544,6 +544,11 @@ ensure_system_partition_size() {
     # Partition is too small - need to expand it
     echo "System partition is too small (${current_size_mb}MB < ${required_size_mb}MB)"
 
+    if abm is-multiboot; then
+        echo "Not expanding system partition due to detecting ABM multi-boot"
+        return 0
+    fi
+
     # Check if LVM expansion is enabled
     use_lvm=$(getprop ro.systemimage.use_lvm)
     if [ "$use_lvm" = "true" ] || [ "$use_lvm" = "1" ]; then
@@ -860,6 +865,24 @@ do
                 part=${2##/}
                 path=$1
 
+                if abm is-multiboot && [ -e "partitions/${part}.img" ] && [ -e "$path" ]; then
+                    case "$part" in
+                        *boot) # e.g. boot (kernel) + vendor_boot (kmods/recovery) & init_boot (halium) ramdisk fragments
+                            echo "Unpacking ${part}.img for multiboot..."
+                            unpackbootimg -i "partitions/${part}.img" >/dev/null
+                            rm "partitions/${part}.img"
+                            ;;
+                        vendor|system_dlkm|vendor_dlkm) # known partition images wanted in multiboot rootfs, follows usual logic
+                            path="$SYSTEM_MOUNTPOINT/var/lib/lxc/android/$part.img"
+                            [ -e "$path" ] || install -m664 /dev/null "$path"
+                            ;;
+                        *)
+                            echo "Ignoring $path update under ABM"
+                            rm "partitions/${part}.img"
+                            ;;
+                    esac
+                fi
+
                 if [ -e partitions/${part}.img ] && [ -e $path ]; then
                     if simgtest partitions/${part}.img 2>/dev/null; then
                         echo "Flashing sparse ${part} at ${path}"
@@ -878,6 +901,23 @@ do
                     rm partitions/${part}.img
                 fi
             done
+
+            # Handle kernel-related "partition" updates for multiboot when all unpacked
+            if [ -f boot.img-kernel ]; then
+                ut_conf="$(abm print-conf)" # e.g. "/bootset/db/entries/rom0.conf"
+                rom="/bootset/${ut_conf##*/}"; rom=${rom%.conf} # e.g. "/bootset/rom0"
+                echo "Updating multiboot kernel files for $rom..."
+                cp boot.img-kernel "$rom/zImage"
+                for ramdisk in "vendor_boot.img-vendor_ramdisk" "init_boot.img-ramdisk" "boot.img-ramdisk"; do
+                    [ -f $ramdisk ] && cat $ramdisk >> boot.img-final-ramdisk
+                done
+                cp boot.img-final-ramdisk "$rom/initrd.cpio.gz"
+                # shellcheck disable=SC3034
+                cmdline="$(<boot.img-cmdline) $(cat vendor_boot.img-vendor_cmdline 2>/dev/null) $(getprop ro.abm.extra_cmdline)"
+                sed -i "s:options .*:options ${cmdline# *}:" "$ut_conf"
+                sync
+                rm *boot.img-*
+            fi
 
             # Remove tarball to free up space, since device tarballs
             # extract partitions/blobs that might fill up cache,


### PR DESCRIPTION
Volla Phone Plinius can now enter UBports recovery in an SD card multi-boot scenario, add initial supporting bits for this
<details>
<summary>Example /cache/ubuntu_updater.log</summary>

```
$ adb shell tail -n0 -f /cache/ubuntu_updater.log
System Image Upgrader for Ubuntu Touch
Preparing command file
Starting image upgrader
Loading keyring: archive-master.tar.xz
Processing command file
Formatting: system
system partition: /dev/block/mmcblk0p2
umount: /system_root: No such file or directory
Required system partition size: 4500MB


Current raw system partition size: 9888MB
System partition size is sufficient, no LVM needed
mke2fs 1.46.6 (1-Feb-2023)
Discarding device blocks: done                            
Creating filesystem with 2531423 4k blocks and 633984 inodes
Filesystem UUID: 197de050-f493-4cb1-b575-fa087309a341
Superblock backups stored on blocks: 
        32768, 98304, 163840, 229376, 294912, 819200, 884736, 1605632

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (16384 blocks): done
Writing superblocks and filesystem accounting information: done 

Loading keyring: image-master.tar.xz
Loading keyring: image-signing.tar.xz
umount: /dev/block/mmcblk0p2: Invalid argument
umount: /cache/system: Invalid argument
umount: /system_root: No such file or directory
umount: /mnt/system: Invalid argument
e2fsck 1.46.6 (1-Feb-2023)
Pass 1: Checking inodes, blocks, and sizes
Pass 2: Checking directory structure
Pass 3: Checking directory connectivity
Pass 4: Checking reference counts
Pass 5: Checking group summary information
/dev/block/mmcblk0p2: 11/633984 files (0.0% non-contiguous), 56187/2531423 blocks
Required system partition size: 4500MB
Current raw system partition size: 9888MB
System partition size is sufficient, no LVM needed
Filesystem size matches device size
Applying update: rootfs-6dee19ffc3d1b33d6fa7314108a58af500fdd765df00330c63484fc80a8f7b16.tar.xz
Applying update: firmware-b543649cb168bc56257dcdbc3c640ff521b16f750b8e7620d3f784f034472ae3.tar.xz
Checking if vendor at /cache/system/var/lib/lxc/android/vendor.img needs updating...
  Flashing (binary content differs)...
Checking if vendor_dlkm at /cache/system/var/lib/lxc/android/vendor_dlkm.img needs updating...
  Flashing (binary content differs)...
Checking if system_dlkm at /cache/system/var/lib/lxc/android/system_dlkm.img needs updating...
  Flashing (binary content differs)...
Applying update: device-229ea56b650d1471490f911eff161507da911a67d51002bb9d22fc0022e6334f.tar.xz
Applying update: boot-b86dd71ccf1a788d113b0579093be97af19378c0da8c43406e3ca59d9cb5c73a.tar.xz
Unpacking init_boot.img for multiboot...
Unpacking boot.img for multiboot...
Unpacking vendor_boot.img for multiboot...
Updating multiboot kernel files for /bootset/rom0...
Applying update: keyring-162141caf64cd64c4ca014760930c524e4ee051e0afe1200c47c42cebf11fd44.tar.xz
Applying update: version-139.tar.xz
Done upgrading...
Mounting /data from fstab
tune2fs 1.46.6 (1-Feb-2023)
Setting reserved blocks percentage to 5% (713923 blocks)
```
</details>
