### PR TITLE
Android.bp & ubports/: Introduce 'chroot-into-system' script

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -199,6 +199,7 @@ cc_binary {
         "archive-master.tar.xz",
         "archive-master.tar.xz.asc",
         "busybox_recovery",
+        "chroot-into-system",
         "e2fsck.recovery",
         "gpg",
         "bsdtar-recovery",

--- a/ubports/Android.mk
+++ b/ubports/Android.mk
@@ -89,6 +89,14 @@ LOCAL_MODULE_PATH := $(TARGET_RECOVERY_ROOT_OUT)/system/bin
 LOCAL_SRC_FILES := $(LOCAL_MODULE)
 include $(BUILD_PREBUILT)
 
+include $(CLEAR_VARS)
+LOCAL_MODULE := chroot-into-system
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := EXECUTABLES
+LOCAL_MODULE_PATH := $(TARGET_RECOVERY_ROOT_OUT)/system/bin
+LOCAL_SRC_FILES := $(LOCAL_MODULE)
+include $(BUILD_PREBUILT)
+
 # UBports prebuilts
 # ===============================
 

--- a/ubports/chroot-into-system
+++ b/ubports/chroot-into-system
@@ -47,6 +47,8 @@ function mount_all_requirements {
         mount_if_missing $SYSTEM/userdata/system-data/var/lib/extrausers $SYSTEM/var/lib/extrausers "-o bind"
     [ -d $SYSTEM/userdata/system-data/var/log ] && \
         mount_if_missing $SYSTEM/userdata/system-data/var/log $SYSTEM/var/log "-o bind"
+    [ -d $SYSTEM/userdata/system-data/var/lib/systemd ] && \
+        mount_if_missing $SYSTEM/userdata/system-data/var/lib/systemd $SYSTEM/var/lib/systemd "-o bind"
 }
 
 function attempt_home_unlock {
@@ -66,4 +68,4 @@ attempt_home_unlock
 
 # Done setting up environment, start chroot now
 export PATH=/usr/sbin:/usr/bin:/bin:/sbin
-chroot $SYSTEM /bin/bash
+chroot $SYSTEM /bin/bash --login

--- a/ubports/chroot-into-system
+++ b/ubports/chroot-into-system
@@ -1,27 +1,48 @@
 #!/system/bin/sh
 
+set -e
+
 # Unified recovery expects this path elsewhere (in fstab, maybe in code)
 SYSTEM=/mnt/system
 
-function mount_all {
-    mount $SYSTEM || echo "Failed to (re-)mount $SYSTEM, proceeding regardless."
+function mount_if_missing {
+    SOURCE=$1
+    MOUNTPOINT=$2
+    OPTIONS=$3
+
+    [ mountpoint -q $MOUNTPOINT ] && return
+
+    mount $OPTIONS $SOURCE $MOUNTPOINT || \
+        echo "Failed to mount $MOUNTPOINT, aborting." && \
+        exit 1
+}
+
+function mount_all_requirements {
+    mountpoint -q $SYSTEM || \
+        echo "Please mount your system partition in the recovery's Advanced Settings first." && \
+        exit 1
 
     # Mount a chrootable system
-    mount -t sysfs none $SYSTEM/sys
-    mount -o bind /proc $SYSTEM/proc
-    mount -o bind /dev $SYSTEM/dev
-    mount -o bind /dev/pts $SYSTEM/dev/pts
+    mount_if_missing none $SYSTEM/sys "-t sysfs"
+    mount_if_missing ubuntu-proc $SYSTEM/proc "-t proc"
+    mount_if_missing /dev $SYSTEM/dev "-o bind"
+    mount_if_missing /dev/pts $SYSTEM/dev/pts "-o bind"
 
     # Mount data with default + auto-detected configuration,
     # the shortest command knows best how to mount userdata.
-    mount /data
+    mount_if_missing "" /data ""
+
+    # Mount user's data partition into chroot
+    mount_if_missing /data $SYSTEM/userdata "-o bind"
 
     # Set up minimal writable paths for accessing an encrypted /home/phablet
-    mount -o bind /data $SYSTEM/userdata
-    mount -o bind $SYSTEM/userdata/user-data $SYSTEM/home
-    mount -o bind $SYSTEM/userdata/system-data/var/lib/extrausers $SYSTEM/var/lib/extrausers
-
-    touch /tmp/all_mounted
+    # and reading system and user logs off the journal.
+    [ -d $SYSTEM/userdata/user-data ] && \
+        mount_if_missing $SYSTEM/userdata/user-data $SYSTEM/home "-o bind"
+    [ -d $SYSTEM/userdata/system-data/var/lib/extrausers ] && \
+        mount_if_missing $SYSTEM/userdata/system-data/var/lib/extrausers $SYSTEM/var/lib/extrausers "-o bind"
+    [ -d $SYSTEM/userdata/system-data/var/log ] && \
+        mount_if_missing $SYSTEM/userdata/system-data/var/log $SYSTEM/var/log "-o bind"
 }
 
 function attempt_home_unlock {
@@ -36,7 +57,9 @@ function attempt_home_unlock {
     chroot $SYSTEM /usr/bin/fscrypt unlock /home/phablet
 }
 
-[ ! -f /tmp/all_mounted ] && mount_all
+mount_all_requirements
 attempt_home_unlock
 
-PATH=/usr/sbin:/usr/bin:/bin:/sbin chroot $SYSTEM /bin/bash
+# Done setting up environment, start chroot now
+export PATH=/usr/sbin:/usr/bin:/bin:/sbin
+chroot $SYSTEM /bin/bash

--- a/ubports/chroot-into-system
+++ b/ubports/chroot-into-system
@@ -52,7 +52,7 @@ function mount_all_requirements {
 }
 
 function attempt_home_unlock {
-    STATUS="$(chroot $SYSTEM /usr/bin/fscrypt status /home/phablet)"
+    STATUS="$(chroot $SYSTEM /usr/bin/fscrypt status /home/phablet 2>&1 || true)"
 
     echo "$STATUS" | grep -q "is not encrypted" && \
         return
@@ -67,5 +67,4 @@ mount_all_requirements
 attempt_home_unlock
 
 # Done setting up environment, start chroot now
-export PATH=/usr/sbin:/usr/bin:/bin:/sbin
-chroot $SYSTEM /bin/bash --login
+chroot $SYSTEM /usr/bin/env PATH=/usr/sbin:/usr/bin:/bin:/sbin bash --login

--- a/ubports/chroot-into-system
+++ b/ubports/chroot-into-system
@@ -1,0 +1,42 @@
+#!/system/bin/sh
+
+# Unified recovery expects this path elsewhere (in fstab, maybe in code)
+SYSTEM=/mnt/system
+
+function mount_all {
+    mount $SYSTEM || echo "Failed to (re-)mount $SYSTEM, proceeding regardless."
+
+    # Mount a chrootable system
+    mount -t sysfs none $SYSTEM/sys
+    mount -o bind /proc $SYSTEM/proc
+    mount -o bind /dev $SYSTEM/dev
+    mount -o bind /dev/pts $SYSTEM/dev/pts
+
+    # Mount data with default + auto-detected configuration,
+    # the shortest command knows best how to mount userdata.
+    mount /data
+
+    # Set up minimal writable paths for accessing an encrypted /home/phablet
+    mount -o bind /data $SYSTEM/userdata
+    mount -o bind $SYSTEM/userdata/user-data $SYSTEM/home
+    mount -o bind $SYSTEM/userdata/system-data/var/lib/extrausers $SYSTEM/var/lib/extrausers
+
+    touch /tmp/all_mounted
+}
+
+function attempt_home_unlock {
+    STATUS="$(chroot $SYSTEM /usr/bin/fscrypt status /home/phablet)"
+
+    echo "$STATUS" | grep -q "is not encrypted" && \
+        return
+
+    echo "$STATUS" | grep -q "Unlocked: Yes" && \
+        return
+
+    chroot $SYSTEM /usr/bin/fscrypt unlock /home/phablet
+}
+
+[ ! -f /tmp/all_mounted ] && mount_all
+attempt_home_unlock
+
+PATH=/usr/sbin:/usr/bin:/bin:/sbin chroot $SYSTEM /bin/bash

--- a/ubports/chroot-into-system
+++ b/ubports/chroot-into-system
@@ -10,17 +10,21 @@ function mount_if_missing {
     MOUNTPOINT=$2
     OPTIONS=$3
 
-    [ mountpoint -q $MOUNTPOINT ] && return
+    if mountpoint -q $MOUNTPOINT; then
+        return
+    fi
 
-    mount $OPTIONS $SOURCE $MOUNTPOINT || \
-        echo "Failed to mount $MOUNTPOINT, aborting." && \
+    if ! mount $OPTIONS $SOURCE $MOUNTPOINT; then
+        echo "Failed to mount $MOUNTPOINT, aborting."
         exit 1
+    fi
 }
 
 function mount_all_requirements {
-    mountpoint -q $SYSTEM || \
-        echo "Please mount your system partition in the recovery's Advanced Settings first." && \
+    if ! mountpoint -q $SYSTEM; then
+        echo "Please mount your system partition in the recovery's Advanced Settings first."
         exit 1
+    fi
 
     # Mount a chrootable system
     mount_if_missing none $SYSTEM/sys "-t sysfs"


### PR DESCRIPTION
The unified recovery gives us a chance to ship convenience scripts for data recovery or porting purposes. One such script is 'chroot-into-system'.

It provides a minimal environment setup enough to access /home/phablet within a system-wide installed Ubuntu Touch installation in /mnt/system. Additionally it verifies whether the phablet home is encrypted and unlocks the directory on demand.

This is just the minimal basis enough to help recover encrypted data or help porters in their jobs of integrating Ubuntu Touch with their selected hardware. The script could be extended to automatically mount all writable-paths of the installed system in the future, right now it only does the bare minimum setup to allow phablet's home directory to be recovered.