### PR TITLE
Fix intermittently missing ADB in recovery

### DIFF
--- a/etc/init.rc
+++ b/etc/init.rc
@@ -246,3 +246,15 @@ on property:sys.usb.config=fastboot && property:sys.usb.ffs.ready=1 && property:
     symlink /config/usb_gadget/g1/functions/ffs.fastboot /config/usb_gadget/g1/configs/b.1/f1
     write /config/usb_gadget/g1/UDC ${sys.usb.controller}
     setprop sys.usb.state ${sys.usb.config}
+
+on property:sys.usb.controller=* && property:sys.usb.config=adb && property:sys.usb.ffs.ready=1 && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/UDC "none"
+    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
+
+on property:sys.usb.controller=* && property:sys.usb.config=sideload && property:sys.usb.ffs.ready=1 && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/UDC "none"
+    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
+
+on property:sys.usb.controller=* && property:sys.usb.config=fastboot && property:sys.usb.ffs.ready=1 && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/UDC "none"
+    write /config/usb_gadget/g1/UDC ${sys.usb.controller}

--- a/ubports/setup-usb
+++ b/ubports/setup-usb
@@ -7,3 +7,17 @@ if [ -e /sys/class/android_usb/android0/enable ]; then
 fi
 
 setprop sys.usb.configfs 1
+
+n=0
+while [ "$n" -lt 600 ]; do
+    for udc in /sys/class/udc/*; do
+        [ -e "$udc" ] || continue
+        case "${udc##*/}" in
+            dummy*) continue ;;
+        esac
+        setprop sys.usb.controller "${udc##*/}"
+        exit 0
+    done
+    n=$((n+1))
+    sleep 0.1 2>/dev/null || sleep 1
+done


### PR DESCRIPTION
Recovery sometimes boots without ADB. init latches sys.usb.controller on the first /sys/class/udc entry it ever sees and never rescans, so with a modular UDC driver the controller can register after adbd already signalled sys.usb.ffs.ready.

Fix: rebind the gadget on sys.usb.controller=* and have setup-usb pin the first real UDC.

Tested on Volla Phone Plinius (halium 14).