### PR TITLE
recovery: map logical partitions when mounting system

### DIFF
--- a/recovery.cpp
+++ b/recovery.cpp
@@ -660,6 +660,7 @@ change_menu:
             ui->Print("Virtual A/B: snapshot partitions creation failed.\n");
             break;
           }
+          map_logical_partitions();
           if (ensure_path_mounted_at(android::fs_mgr::GetSystemRoot(), "/mnt/system") != -1) {
             ui->Print("Mounted /mnt/system.\n");
             mounted = true;


### PR DESCRIPTION
The menu action only set up Virtual A/B snapshots, which is a no-op on other dynamic partition devices, so /dev/block/mapper was empty and the mount failed.